### PR TITLE
feat: ycbust 0.3.0 — TBP objects, download_objects(), objects_exist()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "bevy-sensor"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "bevy",
  "bevy_obj",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,10 +435,13 @@ version = "0.4.6"
 dependencies = [
  "bevy",
  "bevy_obj",
+ "flate2",
  "image",
  "pollster",
+ "reqwest",
  "serde",
  "serde_json",
+ "tar",
  "tempfile",
  "tokio",
  "wgpu 24.0.5",
@@ -5731,9 +5734,9 @@ checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "ycbust"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e9b7e502cb06816b1dbaee1476934806d16de3840dbabe2ad9783f45b6ef2b"
+checksum = "65de09c64520c8e8129571d8372f1960fdff8cfdac3ae0be24a909346d18b83f"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy-sensor"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 description = "Bevy library for capturing multi-view images of 3D OBJ models (YCB dataset) for sensor simulation"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,10 @@ bevy = { version = "0.15.3", default-features = false, features = [
     "zstd",            # Compression for ktx2
 ] }
 bevy_obj = { version = "0.15", features = ["scene"] }
-ycbust = "0.2.4"
+ycbust = "0.3.0"
+reqwest = { version = "0.11", features = ["json"] }
+flate2 = "1.0"
+tar = "0.4"
 image = "0.25"  # For saving PNG/depth images
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,11 +71,19 @@ pub mod cache;
 pub mod fixtures;
 
 // Re-export ycbust types for convenience
-pub use ycbust::{self, DownloadOptions, Subset as YcbSubset, REPRESENTATIVE_OBJECTS, TEN_OBJECTS};
+#[allow(deprecated)]
+pub use ycbust::{
+    self, DownloadOptions, Subset as YcbSubset, REPRESENTATIVE_OBJECTS, TBP_SIMILAR_OBJECTS,
+    TBP_STANDARD_OBJECTS, TEN_OBJECTS,
+};
 
 /// YCB dataset utilities
 pub mod ycb {
-    pub use ycbust::{download_ycb, DownloadOptions, Subset, REPRESENTATIVE_OBJECTS, TEN_OBJECTS};
+    #[allow(deprecated)]
+    pub use ycbust::{
+        download_ycb, DownloadOptions, Subset, REPRESENTATIVE_OBJECTS, TBP_SIMILAR_OBJECTS,
+        TBP_STANDARD_OBJECTS, TEN_OBJECTS,
+    };
 
     use std::path::Path;
 
@@ -115,12 +123,91 @@ pub mod ycb {
         Ok(())
     }
 
-    /// Check if YCB models exist at the given path
+    /// Download a specific list of YCB objects by name.
+    ///
+    /// Only fetches objects whose mesh file is not already present.
+    /// Uses the canonical YCB S3 URL scheme:
+    /// `https://ycb-benchmarks.s3.amazonaws.com/data/google/{id}_google_16k.tgz`
+    ///
+    /// # Example
+    /// ```ignore
+    /// use bevy_sensor::ycb::{download_objects, TBP_STANDARD_OBJECTS};
+    /// download_objects("/tmp/ycb", &TBP_STANDARD_OBJECTS).await?;
+    /// ```
+    pub async fn download_objects<P: AsRef<Path>>(
+        output_dir: P,
+        object_ids: &[&str],
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let path = output_dir.as_ref();
+        std::fs::create_dir_all(path)?;
+
+        let missing: Vec<&&str> = object_ids
+            .iter()
+            .filter(|id| !object_mesh_path(path, id).exists())
+            .collect();
+
+        if missing.is_empty() {
+            return Ok(());
+        }
+
+        let client = reqwest::Client::new();
+
+        for object_id in &missing {
+            let url = format!(
+                "https://ycb-benchmarks.s3.amazonaws.com/data/google/{}_google_16k.tgz",
+                object_id
+            );
+            let tgz_path = path.join(format!("{}_google_16k.tgz", object_id));
+
+            let response = client.get(&url).send().await?;
+            if !response.status().is_success() {
+                return Err(format!(
+                    "HTTP {} downloading {}: {}",
+                    response.status(),
+                    object_id,
+                    url
+                )
+                .into());
+            }
+
+            let bytes = response.bytes().await?;
+            std::fs::write(&tgz_path, &bytes)?;
+
+            let tar_gz = std::fs::File::open(&tgz_path)?;
+            let tar = flate2::read::GzDecoder::new(tar_gz);
+            let mut archive = tar::Archive::new(tar);
+            archive.unpack(path)?;
+            std::fs::remove_file(&tgz_path).ok();
+        }
+        Ok(())
+    }
+
+    /// Check if YCB models exist at the given path.
+    ///
+    /// Checks for all objects in `REPRESENTATIVE_OBJECTS` rather than a single
+    /// hardcoded path so the check stays in sync with the actual default subset.
     pub fn models_exist<P: AsRef<Path>>(output_dir: P) -> bool {
         let path = output_dir.as_ref();
-        // Check for at least one representative object
-        path.join("003_cracker_box/google_16k/textured.obj")
-            .exists()
+        REPRESENTATIVE_OBJECTS
+            .iter()
+            .all(|id| object_mesh_path(path, id).exists())
+    }
+
+    /// Check if a specific set of YCB objects are present at the given path.
+    ///
+    /// Returns `true` only if every object in `object_ids` has a
+    /// `google_16k/textured.obj` mesh file present.
+    ///
+    /// # Example
+    /// ```ignore
+    /// use bevy_sensor::ycb::{objects_exist, TBP_STANDARD_OBJECTS};
+    /// assert!(objects_exist("/tmp/ycb", &TBP_STANDARD_OBJECTS));
+    /// ```
+    pub fn objects_exist<P: AsRef<Path>>(output_dir: P, object_ids: &[&str]) -> bool {
+        let path = output_dir.as_ref();
+        object_ids
+            .iter()
+            .all(|id| object_mesh_path(path, id).exists())
     }
 
     /// Get the path to a specific YCB object's OBJ file

--- a/src/render.rs
+++ b/src/render.rs
@@ -1037,7 +1037,8 @@ pub fn render_headless(
                     exit_condition: ExitCondition::DontExit,
                     ..default()
                 })
-                .disable::<bevy::winit::WinitPlugin>(), // Disable winit entirely
+                .disable::<bevy::winit::WinitPlugin>() // Disable winit entirely
+                .disable::<bevy::log::LogPlugin>(), // Prevent duplicate global logger on re-entry
         )
         .add_plugins(ScheduleRunnerPlugin::run_loop(Duration::from_secs_f64(
             1.0 / 60.0,
@@ -1921,7 +1922,8 @@ pub fn render_to_files(
                     exit_condition: ExitCondition::DontExit,
                     ..default()
                 })
-                .disable::<bevy::winit::WinitPlugin>(),
+                .disable::<bevy::winit::WinitPlugin>() // Disable winit entirely
+                .disable::<bevy::log::LogPlugin>(), // Prevent duplicate global logger on re-entry
         )
         .add_plugins(ScheduleRunnerPlugin::run_loop(Duration::from_secs_f64(
             1.0 / 60.0,

--- a/src/render.rs
+++ b/src/render.rs
@@ -617,7 +617,15 @@ fn collect_depth_captures(
                 }
             }
         }
+
+        // Explicit buffer drop with GPU sync to prevent memory leaks (#71)
+        // This ensures the staging buffer is released before processing more frames
+        drop(buffer);
     }
+
+    // Final GPU sync to ensure all buffer deallocations are processed
+    // This helps prevent SIGSEGV crashes during long benchmark runs (#71)
+    render_device.poll(bevy::render::render_resource::Maintain::Wait);
 }
 
 // ============================================================================
@@ -847,7 +855,15 @@ fn collect_image_captures(
                 }
             }
         }
+
+        // Explicit buffer drop with GPU sync to prevent memory leaks (#71)
+        // This ensures the staging buffer is released before processing more frames
+        drop(buffer);
     }
+
+    // Final GPU sync to ensure all buffer deallocations are processed
+    // This helps prevent SIGSEGV crashes during long benchmark runs (#71)
+    render_device.poll(bevy::render::render_resource::Maintain::Wait);
 }
 
 /// Plugin for headless image copy

--- a/src/render.rs
+++ b/src/render.rs
@@ -964,18 +964,18 @@ pub fn render_headless(
     // Canonicalize paths to absolute paths for Bevy's AssetServer
     // This prevents issues when relative paths (e.g., ../../ycb) are used
     // and the binary runs from a different directory (e.g., target/release)
-    let mesh_path_abs = mesh_path.canonicalize().map_err(|e| {
-        RenderError::FileNotFound {
+    let mesh_path_abs = mesh_path
+        .canonicalize()
+        .map_err(|e| RenderError::FileNotFound {
             path: mesh_path.display().to_string(),
             reason: format!("Failed to canonicalize path: {}", e),
-        }
-    })?;
-    let texture_path_abs = texture_path.canonicalize().map_err(|e| {
-        RenderError::FileNotFound {
+        })?;
+    let texture_path_abs = texture_path
+        .canonicalize()
+        .map_err(|e| RenderError::FileNotFound {
             path: texture_path.display().to_string(),
             reason: format!("Failed to canonicalize path: {}", e),
-        }
-    })?;
+        })?;
 
     let request = RenderRequest {
         mesh_path: mesh_path_abs.display().to_string(),
@@ -1834,18 +1834,18 @@ pub fn render_to_files(
     // Canonicalize paths to absolute paths for Bevy's AssetServer
     // This prevents issues when relative paths (e.g., ../../ycb) are used
     // and the binary runs from a different directory (e.g., target/release)
-    let mesh_path_abs = mesh_path.canonicalize().map_err(|e| {
-        RenderError::FileNotFound {
+    let mesh_path_abs = mesh_path
+        .canonicalize()
+        .map_err(|e| RenderError::FileNotFound {
             path: mesh_path.display().to_string(),
             reason: format!("Failed to canonicalize path: {}", e),
-        }
-    })?;
-    let texture_path_abs = texture_path.canonicalize().map_err(|e| {
-        RenderError::FileNotFound {
+        })?;
+    let texture_path_abs = texture_path
+        .canonicalize()
+        .map_err(|e| RenderError::FileNotFound {
             path: texture_path.display().to_string(),
             reason: format!("Failed to canonicalize path: {}", e),
-        }
-    })?;
+        })?;
 
     let request = RenderRequest {
         mesh_path: mesh_path_abs.display().to_string(),

--- a/src/render.rs
+++ b/src/render.rs
@@ -961,9 +961,25 @@ pub fn render_headless(
         ));
     }
 
+    // Canonicalize paths to absolute paths for Bevy's AssetServer
+    // This prevents issues when relative paths (e.g., ../../ycb) are used
+    // and the binary runs from a different directory (e.g., target/release)
+    let mesh_path_abs = mesh_path.canonicalize().map_err(|e| {
+        RenderError::FileNotFound {
+            path: mesh_path.display().to_string(),
+            reason: format!("Failed to canonicalize path: {}", e),
+        }
+    })?;
+    let texture_path_abs = texture_path.canonicalize().map_err(|e| {
+        RenderError::FileNotFound {
+            path: texture_path.display().to_string(),
+            reason: format!("Failed to canonicalize path: {}", e),
+        }
+    })?;
+
     let request = RenderRequest {
-        mesh_path: mesh_path.display().to_string(),
-        texture_path: texture_path.display().to_string(),
+        mesh_path: mesh_path_abs.display().to_string(),
+        texture_path: texture_path_abs.display().to_string(),
         camera_transform: *camera_transform,
         object_rotation: object_rotation.clone(),
         config: config.clone(),
@@ -1815,9 +1831,25 @@ pub fn render_to_files(
         ));
     }
 
+    // Canonicalize paths to absolute paths for Bevy's AssetServer
+    // This prevents issues when relative paths (e.g., ../../ycb) are used
+    // and the binary runs from a different directory (e.g., target/release)
+    let mesh_path_abs = mesh_path.canonicalize().map_err(|e| {
+        RenderError::FileNotFound {
+            path: mesh_path.display().to_string(),
+            reason: format!("Failed to canonicalize path: {}", e),
+        }
+    })?;
+    let texture_path_abs = texture_path.canonicalize().map_err(|e| {
+        RenderError::FileNotFound {
+            path: texture_path.display().to_string(),
+            reason: format!("Failed to canonicalize path: {}", e),
+        }
+    })?;
+
     let request = RenderRequest {
-        mesh_path: mesh_path.display().to_string(),
-        texture_path: texture_path.display().to_string(),
+        mesh_path: mesh_path_abs.display().to_string(),
+        texture_path: texture_path_abs.display().to_string(),
         camera_transform: *camera_transform,
         object_rotation: object_rotation.clone(),
         config: config.clone(),


### PR DESCRIPTION
## Summary

Bumps ycbust to 0.3.0 and adds first-class support for TBP benchmark object sets.

### Changes
- **ycbust 0.2.4 → 0.3.0**
- **Re-export** `TBP_STANDARD_OBJECTS` and `TBP_SIMILAR_OBJECTS`
- **Fix `models_exist()`** — was checking hardcoded `003_cracker_box`, which is NOT in the TBP standard benchmark set; now checks all `REPRESENTATIVE_OBJECTS`
- **Add `objects_exist(dir, &[ids])`** — check that specific objects are present
- **Add `download_objects(dir, &[ids])`** — download only the listed objects by name; skips already-present objects

### Why
The old `models_exist()` check always passed if `003_cracker_box` was present, even when the TBP benchmark objects (mug, bowl, spoon, etc.) were missing. This caused silent failures where neocortx would run the benchmark against the wrong objects.

`download_objects()` lets callers fetch exactly what they need without pulling an entire preset subset.