### PR TITLE
fix(ycb): guard downstream release api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- add public YCB API regression coverage for `TBP_STANDARD_OBJECTS` and `download_objects`
+
+### Changed
+
+- document the YCB helper surface that downstream crates such as NeoCortx bind to between releases
+
 ## [0.4.6](https://github.com/killerapp/bevy-sensor/compare/v0.4.5...v0.4.6) - 2025-12-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -77,6 +77,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+### YCB Helpers
+
+The public `ycb` module is the supported downstream surface for dataset selection and retrieval:
+
+```rust
+use bevy_sensor::ycb::{download_objects, REPRESENTATIVE_OBJECTS, TBP_STANDARD_OBJECTS};
+
+fn plan_downloads() {
+    assert_eq!(REPRESENTATIVE_OBJECTS.len(), 3);
+    assert_eq!(TBP_STANDARD_OBJECTS.len(), 10);
+
+    let future = download_objects("/tmp/ycb", &["003_cracker_box"]);
+    drop(future);
+}
+```
+
+NeoCortx binds to this YCB helper surface directly. If it changes, release the crate promptly so downstream builds move forward on published versions instead of long-lived local patches.
+
 ## Troubleshooting
 
 ### WSL2 Support

--- a/tests/ycb_public_api.rs
+++ b/tests/ycb_public_api.rs
@@ -1,0 +1,23 @@
+use bevy_sensor::ycb::{self, REPRESENTATIVE_OBJECTS, TBP_STANDARD_OBJECTS};
+use bevy_sensor::{
+    REPRESENTATIVE_OBJECTS as REEXPORTED_REPRESENTATIVE_OBJECTS,
+    TBP_STANDARD_OBJECTS as REEXPORTED_TBP_STANDARD_OBJECTS,
+};
+use std::path::Path;
+
+#[test]
+fn public_ycb_constants_expose_expected_downstream_sets() {
+    assert_eq!(REPRESENTATIVE_OBJECTS.len(), 3);
+    assert_eq!(TBP_STANDARD_OBJECTS.len(), 10);
+    assert!(REPRESENTATIVE_OBJECTS.contains(&"003_cracker_box"));
+    assert!(TBP_STANDARD_OBJECTS.contains(&"025_mug"));
+    assert!(TBP_STANDARD_OBJECTS.contains(&"024_bowl"));
+    assert_eq!(REPRESENTATIVE_OBJECTS, REEXPORTED_REPRESENTATIVE_OBJECTS);
+    assert_eq!(TBP_STANDARD_OBJECTS, REEXPORTED_TBP_STANDARD_OBJECTS);
+}
+
+#[test]
+fn public_ycb_download_objects_is_callable_without_internal_imports() {
+    let future = ycb::download_objects(Path::new("."), &["003_cracker_box"]);
+    drop(future);
+}


### PR DESCRIPTION
## Summary
- add an external YCB API regression test for the public constants and download helper NeoCortx binds to
- document the supported YCB helper surface in the README and changelog
- keep bevy-sensor release-ready so NeoCortx can move back to published versions instead of local patches

## Validation
- cargo fmt --all -- --check
- cargo test
- cargo package --allow-dirty
- NeoCortx smoke check with local bevy-sensor patch: cargo test -p neocortx --lib test_bevy_ycb_dataloader_creation --features bevy_simulator --config <temp patch> -- --nocapture