### PR TITLE
fix(render): stabilize batch headless validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "bevy-sensor"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "bevy",
  "bevy_obj",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy-sensor"
-version = "0.4.7"
+version = "0.4.8"
 edition = "2021"
 description = "Bevy library for capturing multi-view images of 3D OBJ models (YCB dataset) for sensor simulation"
 license = "MIT"

--- a/src/render.rs
+++ b/src/render.rs
@@ -94,6 +94,7 @@ struct RenderState {
     frame_count: u32,
     scene_loaded: bool,
     texture_loaded: bool,
+    materials_applied: bool,
     capture_ready: bool,
     screenshot_requested: bool,
     captured: bool,
@@ -1166,6 +1167,12 @@ pub fn render_headless_sequence(
             .chain(),
     );
 
+    // Manual app.update() loops do not run plugin finish/cleanup hooks automatically.
+    // Bevy's screenshot plugin inserts CapturedScreenshots during finish(), so run the
+    // normal startup phases before driving the headless batch loop ourselves.
+    app.finish();
+    app.cleanup();
+
     let timeout = std::time::Duration::from_secs(60);
     let start = std::time::Instant::now();
 
@@ -1462,29 +1469,25 @@ fn apply_materials(
 
     let Some(tex) = texture else { return };
 
-    // Create textured material
-    let textured_material = materials.add(StandardMaterial {
-        base_color_texture: Some(tex.0.clone()),
-        unlit: true,
-        ..default()
-    });
+    if !state.materials_applied {
+        // Create and assign the textured material once, then let the scene warm up.
+        let textured_material = materials.add(StandardMaterial {
+            base_color_texture: Some(tex.0.clone()),
+            unlit: true,
+            ..default()
+        });
 
-    // Apply to all meshes
-    let mut count = 0;
-    for mut mat in mesh_query.iter_mut() {
-        mat.0 = textured_material.clone();
-        count += 1;
-    }
+        for mut mat in mesh_query.iter_mut() {
+            mat.0 = textured_material.clone();
+        }
 
-    if count > 0 {
-        println!("Applied texture to {} meshes", count);
+        state.materials_applied = true;
     }
 
     // Wait more frames after applying materials
     // Software rendering (llvmpipe) needs more frames to fully render
     if state.frame_count >= 60 {
         state.capture_ready = true;
-        println!("Ready to capture (frame {})", state.frame_count);
     }
 }
 
@@ -1793,8 +1796,6 @@ fn request_headless_capture(
     {
         return;
     }
-
-    println!("Requesting capture at frame {}", state.frame_count);
 
     // Enable the ImageCopier to trigger RGBA extraction
     for mut copier in query.iter_mut() {

--- a/tests/render_integration.rs
+++ b/tests/render_integration.rs
@@ -17,11 +17,13 @@
 //! - Depth buffer readback works
 
 use bevy_sensor::{
-    backend::detect_platform, cache::ModelCache, render_to_buffer, render_to_buffer_cached,
-    ObjectRotation, RenderConfig, RenderOutput, ViewpointConfig,
+    backend::detect_platform, batch::BatchRenderRequest, cache::ModelCache, render_batch,
+    render_to_buffer, render_to_buffer_cached, BatchRenderConfig, ObjectRotation, RenderConfig,
+    RenderOutput, ViewpointConfig,
 };
 use std::fs;
 use std::path::PathBuf;
+use std::time::Instant;
 
 /// Save render output to test_fixtures/test_renders for inspection
 fn save_render_output(output: &RenderOutput, name: &str) -> Result<(), Box<dyn std::error::Error>> {
@@ -154,6 +156,88 @@ fn test_render_integration() {
     }
 
     println!("✓ Integration test passed");
+}
+
+#[test]
+#[ignore] // Skip in CI - run manually on hardware/render-capable environments
+fn test_batch_render_matches_sequential_episode_outputs() {
+    println!("\n=== Batch vs Sequential Render Test ===");
+
+    let object_dir = PathBuf::from("/tmp/ycb/003_cracker_box");
+    if !object_dir.exists() {
+        println!("⚠ Skipping - YCB models not found");
+        return;
+    }
+
+    let viewpoint_config = ViewpointConfig::default();
+    let viewpoints = bevy_sensor::generate_viewpoints(&viewpoint_config);
+    let selected_viewpoints: Vec<_> = viewpoints.into_iter().take(3).collect();
+    let rotation = ObjectRotation::identity();
+    let config = RenderConfig::tbp_default();
+
+    let sequential_start = Instant::now();
+    let sequential_outputs: Vec<_> = selected_viewpoints
+        .iter()
+        .map(|viewpoint| {
+            render_to_buffer(&object_dir, viewpoint, &rotation, &config)
+                .expect("Sequential render failed")
+        })
+        .collect();
+    let sequential_elapsed = sequential_start.elapsed();
+
+    let batch_requests: Vec<_> = selected_viewpoints
+        .iter()
+        .map(|viewpoint| BatchRenderRequest {
+            object_dir: object_dir.clone(),
+            viewpoint: *viewpoint,
+            object_rotation: rotation.clone(),
+            render_config: config.clone(),
+        })
+        .collect();
+
+    let batch_start = Instant::now();
+    let batch_outputs =
+        render_batch(batch_requests, &BatchRenderConfig::default()).expect("Batch render failed");
+    let batch_elapsed = batch_start.elapsed();
+
+    assert_eq!(batch_outputs.len(), sequential_outputs.len());
+
+    for (idx, (batch_output, sequential_output)) in batch_outputs
+        .iter()
+        .zip(sequential_outputs.iter())
+        .enumerate()
+    {
+        assert_eq!(batch_output.request.viewpoint, selected_viewpoints[idx]);
+        assert_eq!(batch_output.request.object_rotation, rotation);
+        assert_eq!(batch_output.width, sequential_output.width);
+        assert_eq!(batch_output.height, sequential_output.height);
+        assert_eq!(batch_output.intrinsics, sequential_output.intrinsics);
+        assert_eq!(batch_output.rgba, sequential_output.rgba);
+        assert_eq!(batch_output.depth.len(), sequential_output.depth.len());
+
+        let max_depth_delta = batch_output
+            .depth
+            .iter()
+            .zip(sequential_output.depth.iter())
+            .map(|(lhs, rhs)| (lhs - rhs).abs())
+            .fold(0.0_f64, f64::max);
+        assert!(
+            max_depth_delta <= 1e-9,
+            "Depth mismatch at viewpoint {idx}: max delta {max_depth_delta}"
+        );
+    }
+
+    println!(
+        "  Sequential: {:.2}s for {} viewpoints",
+        sequential_elapsed.as_secs_f64(),
+        sequential_outputs.len()
+    );
+    println!(
+        "  Batch: {:.2}s for {} viewpoints",
+        batch_elapsed.as_secs_f64(),
+        batch_outputs.len()
+    );
+    println!("✓ Batch and sequential outputs matched");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- initialize Bevy plugin finish/cleanup before manually driving the batch headless app
- stop reapplying materials every frame while waiting for capture warmup
- add an ignored hardware integration test that compares batch output against sequential rendering

## Validation
- cargo check
- cargo check -p neocortx --features bevy_simulator --config "patch.crates-io.bevy-sensor.path='../bevy-sensor'"
- cargo test --test render_integration test_batch_render_matches_sequential_episode_outputs -- --ignored --nocapture
- cargo test -p neocortx test_ycb_pipeline_integration --features bevy_simulator --config "patch.crates-io.bevy-sensor.path='../bevy-sensor'" -- --nocapture
- cargo run --release -p neocortx --bin exp_ycb --features bevy_simulator --config "patch.crates-io.bevy-sensor.path='../bevy-sensor'" -- quick --train-viewpoints 1 --eval-viewpoints 1 --ycb-dir /tmp/ycb --output-dir output/ticket138-smoke --parity-trace --parity-trace-mode failures-only

Note: the targeted tests passed before a later retry hit local Windows linker/paging-file issues; the compile checks remained green after the final cleanup.

Related: killerapp/neocortx#138
