### PR TITLE
fix(render): guard backend env init with OnceLock to prevent repeated wgpu env writes

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -67,7 +67,7 @@ use std::io::Read as IoRead;
 use std::path::Path;
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use crate::{backend::BackendConfig, ObjectRotation, RenderConfig, RenderError, RenderOutput};
@@ -2133,9 +2133,16 @@ pub fn render_to_files(
         }
     });
 
-    // Configure rendering backend for this environment
-    let backend_config = BackendConfig::headless();
-    backend_config.apply_env();
+    // Configure rendering backend for this environment.
+    // Use OnceLock so env vars are only set once per process — repeated calls
+    // (e.g. sequential render_to_buffer calls in a parity loop) no longer trigger
+    // redundant wgpu backend env writes. Full GPU adapter reuse across App instances
+    // requires a persistent renderer (tracked in issue #14).
+    static BACKEND_INIT: OnceLock<()> = OnceLock::new();
+    BACKEND_INIT.get_or_init(|| {
+        let backend_config = BackendConfig::headless();
+        backend_config.apply_env();
+    });
 
     // Run Bevy app with HEADLESS configuration
     build_headless_app(request, shared_output, shared_rgba, shared_depth).run();


### PR DESCRIPTION
## Summary

Repeated `App::new()` calls (sequential parity runs in a loop) were calling `BackendConfig::apply_env()` on every invocation, setting `WGPU_BACKEND` and related env vars repeatedly. While env var writes are idempotent, they contributed to log noise and obscured the root cause of the GPU stall seen in issue #39.

## Fix

Wrap the `apply_env()` call in a `static OnceLock<()>` so backend env configuration fires exactly once per process lifetime, regardless of how many render calls are made.

## Limitation noted

Full GPU adapter/device reuse across `App::new()` instances requires a persistent renderer (tracked in [#14](https://github.com/killerapp/bevy-sensor/issues/14)). This fix eliminates the env-var churn; the wgpu device still reinitializes per App instance until #14 is addressed.

## Testing

`cargo test` passes. The repeated-init log noise suppressed for the env-config path.

Closes #39