### PR TITLE
fix(render): canonicalize object paths for Bevy asset server

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -977,6 +977,16 @@ pub fn render_headless(
     object_rotation: &ObjectRotation,
     config: &RenderConfig,
 ) -> Result<RenderOutput, RenderError> {
+    // Canonicalize paths so Bevy's asset server can find them regardless of
+    // caller working directory. Relative paths like "../../ycb" pass the
+    // exists() check but Bevy resolves assets against its own root.
+    let object_dir = std::fs::canonicalize(object_dir).map_err(|e| {
+        RenderError::RenderFailed(format!(
+            "Cannot canonicalize object directory {}: {}",
+            object_dir.display(),
+            e
+        ))
+    })?;
     let mesh_path = object_dir.join("google_16k/textured.obj");
     let texture_path = object_dir.join("google_16k/texture_map.png");
 
@@ -1075,6 +1085,13 @@ pub fn render_headless_sequence(
         return Ok(Vec::new());
     }
 
+    let object_dir = std::fs::canonicalize(object_dir).map_err(|e| {
+        RenderError::RenderFailed(format!(
+            "Cannot canonicalize object directory {}: {}",
+            object_dir.display(),
+            e
+        ))
+    })?;
     let mesh_path = object_dir.join("google_16k/textured.obj");
     let texture_path = object_dir.join("google_16k/texture_map.png");
 


### PR DESCRIPTION
## Summary
- Canonicalize `object_dir` paths in `render_headless` and `render_headless_sequence` before passing them to Bevy's asset server
- Fixes render timeouts when callers use relative paths (e.g. `../../ycb`) — Bevy resolves assets against its own root, not the caller's CWD
- Root cause: `Path::exists()` resolves relative paths correctly, but Bevy's OBJ loader fails silently, the scene loads empty, the capture pipeline never triggers, and the 60s watchdog kills the process

## Test plan
- [x] `diag_render ../../ycb` — was timing out, now renders in <1s
- [x] `exp_ycb quick --ycb-dir ../../ycb` — 3-object benchmark completes at 98.41% on Windows
- [x] bevy-sensor standalone examples (`test_render`, `batch_render_neocortx`) still pass with absolute paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)