### PR TITLE
fix(render): drop legacy 60-frame scene-warmup gate

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -121,6 +121,10 @@ struct RenderState {
     scene_loaded: bool,
     texture_loaded: bool,
     materials_applied: bool,
+    /// `frame_count` at the moment materials were applied; used to gate
+    /// `capture_ready` on N frames of render-graph propagation rather than
+    /// a legacy llvmpipe-era 60-frame wait.
+    materials_applied_frame: u32,
     capture_ready: bool,
     screenshot_requested: bool,
     captured: bool,
@@ -1690,15 +1694,15 @@ fn apply_materials(
 
     state.frame_count += 1;
 
-    // Wait a few frames for everything to settle
-    if state.frame_count < 10 {
-        return;
-    }
-
     let Some(tex) = texture else { return };
 
     if !state.materials_applied {
-        // Create and assign the textured material once, then let the scene warm up.
+        // The scene hierarchy is instantiated asynchronously after the asset
+        // load event fires; wait until mesh entities exist before applying.
+        if mesh_query.is_empty() {
+            return;
+        }
+
         let textured_material = materials.add(StandardMaterial {
             base_color_texture: Some(tex.0.clone()),
             unlit: true,
@@ -1710,11 +1714,13 @@ fn apply_materials(
         }
 
         state.materials_applied = true;
+        state.materials_applied_frame = state.frame_count;
     }
 
-    // Wait more frames after applying materials
-    // Software rendering (llvmpipe) needs more frames to fully render
-    if state.frame_count >= 60 {
+    // Two frames after material application is enough for the render graph
+    // to pick up the new material on native GPU. The previous 60-frame gate
+    // was a legacy llvmpipe software-rendering cushion.
+    if state.frame_count >= state.materials_applied_frame + 2 {
         let was_ready = state.capture_ready;
         state.capture_ready = true;
         if render_trace_enabled() && !was_ready {


### PR DESCRIPTION
## Summary

Drops the hardcoded `frame_count >= 60` gate in `apply_materials`, which was a legacy llvmpipe software-rendering cushion. On native GPU per the cold-init trace in #55 (commit afb00fa), the scene is `LoadedWithDependencies` at `frame_count=1` — 58 of those 60 frames were pure idle spin.

Replaced with content-based gating:
1. Don't apply materials until `mesh_query` is non-empty (was guarded by arbitrary `frame_count < 10` wait).
2. Flip `capture_ready` two frames after materials applied — enough for render graph propagation, untied from any software-rendering budget.

Expected saving: ~1.7 s on a 60-episode 10-obj parity-gate (small but free — one-line removal of a comment that explicitly explained the hack).

## Test plan

- [x] `cargo build --release`
- [x] `cargo test --lib` — 82 passed
- [ ] **Pixel-exact hardware test (native GPU required, WSL2 cannot run):**
  ```
  cargo test --release --test render_integration \
    -- --ignored test_batch_render_matches_sequential_episode_outputs --nocapture
  ```
  Must pass pixel-exact + depth delta ≤ 1e-9 vs. sequential. This is the correctness gate for merging.
- [ ] Optional: re-run the parity-gate on neocortx's `profile/parity-gate-timings` branch to confirm the ~1.7 s delta on the 10-obj run.

## Scope

This is deliberately a small, self-contained change that doesn't depend on the larger persistent-App work (#54). It stands on its own and ships even if `RenderSession` takes longer.

Refs: #55