### PR TITLE
feat!(ycb): bump ycbust 0.3 -> 0.4.0 + labeled contract tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,6 +297,17 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
@@ -304,6 +315,18 @@ dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
  "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "futures-io",
  "pin-project-lite",
 ]
 
@@ -333,6 +356,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.2",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,10 +400,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite",
+ "rustix 1.1.2",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.2",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-tar"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1937db2d56578aa3919b9bdb0e5100693fd7d1c0f145c53eb81fbb03e217550"
+dependencies = [
+ "async-std",
+ "filetime",
+ "libc",
+ "pin-project",
+ "redox_syscall 0.2.16",
+ "xattr 0.2.3",
+]
+
+[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -363,6 +507,21 @@ checksum = "f52e8890bb9844440d0c412fa74b67fd2f14e85248b6e00708059b6da9e5f8bf"
 dependencies = [
  "portable-atomic",
  "portable-atomic-util",
+]
+
+[[package]]
+name = "attohttpc"
+version = "0.28.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07a9b245ba0739fc90935094c29adbaee3f977218b5fb95e822e261cda7f56a3"
+dependencies = [
+ "http 1.4.0",
+ "log",
+ "rustls 0.23.39",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -415,10 +574,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-creds"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f84143206b9c72b3c5cb65415de60c7539c79cd1559290fddec657939131be0"
+dependencies = [
+ "attohttpc",
+ "home",
+ "log",
+ "quick-xml",
+ "rust-ini",
+ "serde",
+ "thiserror 1.0.69",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "aws-region"
+version = "0.25.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9aed3f9c7eac9be28662fdb3b0f4d1951e812f7c64fed4f0327ba702f459b3b"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bevy"
@@ -433,6 +624,7 @@ dependencies = [
 name = "bevy-sensor"
 version = "0.5.0"
 dependencies = [
+ "anyhow",
  "bevy",
  "bevy_obj",
  "image",
@@ -939,7 +1131,7 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4aa9d7df5c2b65540093b8402aceec0a55d67b54606e57ce2969abe280b4c48"
 dependencies = [
- "async-channel",
+ "async-channel 2.5.0",
  "bevy_app",
  "bevy_asset",
  "bevy_color",
@@ -1251,6 +1443,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,7 +1475,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
- "async-channel",
+ "async-channel 2.5.0",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -1468,6 +1669,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1605,6 +1823,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,6 +1881,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1677,6 +1914,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
+
+[[package]]
 name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1695,6 +1942,17 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1739,6 +1997,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
  "libloading",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -2043,12 +2310,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -2056,6 +2339,17 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -2105,6 +2399,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -2114,6 +2409,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -2188,6 +2493,18 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "glow"
@@ -2284,7 +2601,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
  "indexmap",
  "slab",
  "tokio",
@@ -2342,6 +2659,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hexasphere"
 version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2359,6 +2682,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2370,13 +2711,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
  "pin-project-lite",
 ]
 
@@ -2403,7 +2754,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.12",
  "http-body",
  "httparse",
  "httpdate",
@@ -2414,6 +2765,20 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -2719,6 +3084,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2811,6 +3185,9 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "loop9"
@@ -2840,6 +3217,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-async"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2848,6 +3236,12 @@ dependencies = [
  "cfg-if",
  "rayon",
 ]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -3115,6 +3509,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -3491,6 +3891,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3654,6 +4064,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "pp-rs"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3747,6 +4163,16 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "quote"
@@ -3922,6 +4348,15 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
@@ -3988,13 +4423,13 @@ version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.12",
  "http-body",
  "hyper",
  "hyper-tls",
@@ -4031,15 +4466,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ron"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bitflags 2.10.0",
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
+
+[[package]]
+name = "rust-s3"
+version = "0.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3df3f353b1f4209dcf437d777cda90279c397ab15a0cd6fd06bd32c88591533"
+dependencies = [
+ "async-trait",
+ "aws-creds",
+ "aws-region",
+ "base64 0.22.1",
+ "bytes",
+ "cfg-if",
+ "futures",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "hyper",
+ "hyper-rustls",
+ "log",
+ "maybe-async",
+ "md5",
+ "percent-encoding",
+ "quick-xml",
+ "rustls 0.21.12",
+ "rustls-native-certs",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha2",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "url",
 ]
 
 [[package]]
@@ -4075,12 +4571,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.13",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -4127,6 +4691,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "security-framework"
@@ -4210,6 +4784,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -4360,6 +4945,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4416,7 +5007,7 @@ checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
 dependencies = [
  "filetime",
  "libc",
- "xattr",
+ "xattr 1.6.1",
 ]
 
 [[package]]
@@ -4505,6 +5096,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4587,6 +5209,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4594,6 +5237,7 @@ checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -4762,6 +5406,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "typewit"
 version = "1.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4796,6 +5446,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -4847,6 +5503,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "vcpkg"
@@ -4983,6 +5645,24 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5691,6 +6371,15 @@ checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
@@ -5732,20 +6421,26 @@ checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "ycbust"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65de09c64520c8e8129571d8372f1960fdff8cfdac3ae0be24a909346d18b83f"
+checksum = "c2a629db7c12d4ac5f5347bf91b6bb6bf13e73232563aeb633c2388d33f63844"
 dependencies = [
  "anyhow",
+ "async-compression",
+ "async-tar",
  "clap",
  "flate2",
  "futures-util",
  "indicatif",
+ "pin-project-lite",
  "reqwest",
+ "rust-s3",
  "serde",
  "serde_json",
  "tar",
+ "thiserror 1.0.69",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -5811,6 +6506,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6421,9 +6421,9 @@ checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "ycbust"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a629db7c12d4ac5f5347bf91b6bb6bf13e73232563aeb633c2388d33f63844"
+checksum = "629ad24455b124695651ba7f5d67e08fc0513adc294cfdd4f644cd791bfba53d"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ bevy = { version = "0.15.3", default-features = false, features = [
     "zstd",            # Compression for ktx2
 ] }
 bevy_obj = { version = "0.15", features = ["scene"] }
-ycbust = { version = "0.4.0", features = ["blocking"] }
+ycbust = { version = "0.4.1", features = ["blocking"] }
 image = "0.25"  # For saving PNG/depth images
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,17 +29,26 @@ bevy = { version = "0.15.3", default-features = false, features = [
     "zstd",            # Compression for ktx2
 ] }
 bevy_obj = { version = "0.15", features = ["scene"] }
-ycbust = "0.3"
+ycbust = { version = "0.4.0", features = ["blocking"] }
 image = "0.25"  # For saving PNG/depth images
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 reqwest = "0.11"
 
+[features]
+default = []
+# Enable ycbust's S3 streaming support for integration tests that exercise
+# the upstream `ycbust::s3` surface. Not used by runtime code.
+ycbust-s3 = ["ycbust/s3"]
+
 [dev-dependencies]
 tempfile = "3.10"
 pollster = "0.4.0"
 wgpu = "24.0"
+# For `ycbust_contract_error_from_and_into_anyhow` — verifies the bidirectional
+# `YcbError` ↔ `anyhow::Error` conversion upstream guarantees.
+anyhow = "1.0"
 
 [[bin]]
 name = "prerender"

--- a/src/bin/prerender.rs
+++ b/src/bin/prerender.rs
@@ -13,6 +13,7 @@
 //!   cargo run --bin prerender -- --single-render --object <name> --rotation <idx> --viewpoint <idx> --output <dir>
 
 use bevy_sensor::ycb;
+use bevy_sensor::ycbust;
 use bevy_sensor::{generate_viewpoints, ObjectRotation, RenderConfig, ViewpointConfig};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -120,8 +121,11 @@ fn run_single_render_impl(args: &[String]) -> Result<(), Box<dyn std::error::Err
         println!("\nYCB models not found at {:?}", ycb_dir);
         println!("Downloading representative models...");
 
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        if let Err(e) = rt.block_on(ycb::download_models(&ycb_dir, ycb::Subset::Representative)) {
+        if let Err(e) = ycbust::blocking::download_ycb_blocking(
+            ycb::Subset::Representative,
+            &ycb_dir,
+            ycbust::DownloadOptions::default(),
+        ) {
             eprintln!("Failed to download models: {}", e);
             std::process::exit(1);
         }
@@ -201,8 +205,11 @@ fn run_batch_render_impl(args: &[String]) -> Result<(), Box<dyn std::error::Erro
         println!("\nYCB models not found at {:?}", ycb_dir);
         println!("Downloading representative models...");
 
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        if let Err(e) = rt.block_on(ycb::download_models(&ycb_dir, ycb::Subset::Representative)) {
+        if let Err(e) = ycbust::blocking::download_ycb_blocking(
+            ycb::Subset::Representative,
+            &ycb_dir,
+            ycbust::DownloadOptions::default(),
+        ) {
             eprintln!("Failed to download models: {}", e);
             std::process::exit(1);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,21 +71,18 @@ pub mod cache;
 pub mod fixtures;
 
 // Re-export ycbust types for convenience
-#[allow(deprecated)]
 pub use ycbust::{
-    self, DownloadOptions, Subset as YcbSubset, REPRESENTATIVE_OBJECTS, TBP_STANDARD_OBJECTS,
-    TEN_OBJECTS,
+    self, DownloadOptions, Subset as YcbSubset, REPRESENTATIVE_OBJECTS, TBP_SIMILAR_OBJECTS,
+    TBP_STANDARD_OBJECTS,
 };
 
 /// YCB dataset utilities
 pub mod ycb {
-    #[allow(deprecated)]
     pub use ycbust::{
-        download_ycb, DownloadOptions, Subset, REPRESENTATIVE_OBJECTS, TBP_STANDARD_OBJECTS,
-        TEN_OBJECTS,
+        download_ycb, DownloadOptions, Subset, REPRESENTATIVE_OBJECTS, TBP_SIMILAR_OBJECTS,
+        TBP_STANDARD_OBJECTS,
     };
 
-    use reqwest::Client;
     use std::path::Path;
 
     /// Download YCB models to the specified directory.
@@ -104,13 +101,7 @@ pub mod ycb {
         output_dir: P,
         subset: Subset,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let options = DownloadOptions {
-            overwrite: false,
-            full: false,
-            show_progress: true,
-            delete_archives: true,
-        };
-        download_ycb(subset, output_dir.as_ref(), options).await?;
+        download_ycb(subset, output_dir.as_ref(), DownloadOptions::default()).await?;
         Ok(())
     }
 
@@ -125,51 +116,27 @@ pub mod ycb {
     }
 
     /// Download specific YCB objects by object ID using the standard `google_16k` meshes.
+    ///
+    /// Thin wrapper over [`ycbust::download_objects`] (added upstream in v0.3.3):
+    /// preserves this crate's ergonomic `P: AsRef<Path>` surface while delegating
+    /// skip / resume / integrity / parallelism to the upstream implementation.
     pub async fn download_objects<P: AsRef<Path>>(
         output_dir: P,
         object_ids: &[&str],
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let output_dir = output_dir.as_ref();
-        let client = Client::new();
-        let options = DownloadOptions {
-            overwrite: false,
-            full: false,
-            show_progress: true,
-            delete_archives: true,
-        };
-
-        std::fs::create_dir_all(output_dir)?;
-
-        for object_id in object_ids {
-            let url = ycbust::get_tgz_url(object_id, "google_16k");
-            let archive_path = output_dir.join(format!("{object_id}_google_16k.tgz"));
-
-            if archive_path.exists() && !options.overwrite {
-                continue;
-            }
-
-            ycbust::download_file(&client, &url, &archive_path, options.show_progress).await?;
-            ycbust::extract_tgz(&archive_path, output_dir, options.delete_archives)?;
-        }
-
+        ycbust::download_objects(object_ids, output_dir.as_ref(), DownloadOptions::default())
+            .await?;
         Ok(())
     }
 
     /// Check if YCB models exist at the given path
     pub fn models_exist<P: AsRef<Path>>(output_dir: P) -> bool {
-        let path = output_dir.as_ref();
-        // Check for at least one representative object
-        path.join("003_cracker_box/google_16k/textured.obj")
-            .exists()
+        ycbust::object_mesh_path(output_dir.as_ref(), "003_cracker_box").exists()
     }
 
     /// Get the path to a specific YCB object's OBJ file
     pub fn object_mesh_path<P: AsRef<Path>>(output_dir: P, object_id: &str) -> std::path::PathBuf {
-        output_dir
-            .as_ref()
-            .join(object_id)
-            .join("google_16k")
-            .join("textured.obj")
+        ycbust::object_mesh_path(output_dir.as_ref(), object_id)
     }
 
     /// Get the path to a specific YCB object's texture file
@@ -177,11 +144,7 @@ pub mod ycb {
         output_dir: P,
         object_id: &str,
     ) -> std::path::PathBuf {
-        output_dir
-            .as_ref()
-            .join(object_id)
-            .join("google_16k")
-            .join("texture_map.png")
+        ycbust::object_texture_path(output_dir.as_ref(), object_id)
     }
 }
 
@@ -1321,10 +1284,15 @@ mod tests {
     }
 
     #[test]
-    #[allow(deprecated)]
-    fn test_ycb_ten_objects() {
-        // Verify ten objects subset is defined
-        assert_eq!(crate::ycb::TEN_OBJECTS.len(), 10);
+    fn test_ycb_tbp_standard_objects() {
+        assert_eq!(crate::ycb::TBP_STANDARD_OBJECTS.len(), 10);
+        assert!(crate::ycb::TBP_STANDARD_OBJECTS.contains(&"025_mug"));
+    }
+
+    #[test]
+    fn test_ycb_tbp_similar_objects() {
+        assert_eq!(crate::ycb::TBP_SIMILAR_OBJECTS.len(), 10);
+        assert!(crate::ycb::TBP_SIMILAR_OBJECTS.contains(&"003_cracker_box"));
     }
 
     #[test]

--- a/src/render.rs
+++ b/src/render.rs
@@ -71,6 +71,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use crate::{backend::BackendConfig, ObjectRotation, RenderConfig, RenderError, RenderOutput};
+use ycbust::{GOOGLE_16K_MESH_RELATIVE, GOOGLE_16K_TEXTURE_RELATIVE};
 
 /// Watchdog timeout for a single render, in seconds.
 ///
@@ -1095,8 +1096,8 @@ pub fn render_headless(
             e
         ))
     })?;
-    let mesh_path = object_dir.join("google_16k/textured.obj");
-    let texture_path = object_dir.join("google_16k/texture_map.png");
+    let mesh_path = object_dir.join(GOOGLE_16K_MESH_RELATIVE);
+    let texture_path = object_dir.join(GOOGLE_16K_TEXTURE_RELATIVE);
 
     if !mesh_path.exists() {
         return Err(RenderError::MeshNotFound(mesh_path.display().to_string()));
@@ -1203,8 +1204,8 @@ pub fn render_headless_sequence(
             e
         ))
     })?;
-    let mesh_path = object_dir.join("google_16k/textured.obj");
-    let texture_path = object_dir.join("google_16k/texture_map.png");
+    let mesh_path = object_dir.join(GOOGLE_16K_MESH_RELATIVE);
+    let texture_path = object_dir.join(GOOGLE_16K_TEXTURE_RELATIVE);
 
     if !mesh_path.exists() {
         return Err(RenderError::MeshNotFound(mesh_path.display().to_string()));
@@ -2626,8 +2627,8 @@ impl RenderSession {
                 e
             ))
         })?;
-        let mesh_path = object_dir.join("google_16k/textured.obj");
-        let texture_path = object_dir.join("google_16k/texture_map.png");
+        let mesh_path = object_dir.join(GOOGLE_16K_MESH_RELATIVE);
+        let texture_path = object_dir.join(GOOGLE_16K_TEXTURE_RELATIVE);
         if !mesh_path.exists() {
             return Err(BatchRenderError::InvalidConfig(format!(
                 "Mesh not found: {}",
@@ -2766,8 +2767,8 @@ pub fn render_to_files(
     rgba_path: &Path,
     depth_path: &Path,
 ) -> Result<(), RenderError> {
-    let mesh_path = object_dir.join("google_16k/textured.obj");
-    let texture_path = object_dir.join("google_16k/texture_map.png");
+    let mesh_path = object_dir.join(GOOGLE_16K_MESH_RELATIVE);
+    let texture_path = object_dir.join(GOOGLE_16K_TEXTURE_RELATIVE);
 
     if !mesh_path.exists() {
         return Err(RenderError::MeshNotFound(mesh_path.display().to_string()));

--- a/tests/ycbust_contract.rs
+++ b/tests/ycbust_contract.rs
@@ -1,0 +1,365 @@
+//! ycbust surface contract tests.
+//!
+//! These tests pin the subset of the `ycbust` public API that `bevy-sensor`
+//! depends on. They are **offline** (no network), and failures after bumping
+//! the `ycbust` version indicate either:
+//!
+//!   (a) a compatible API change we should propagate here, or
+//!   (b) an upstream regression to coordinate with the ycbust team
+//!       (<https://github.com/Agentic-Insights/ycbust>).
+//!
+//! Conventions:
+//! - All tests prefixed `ycbust_contract_` so `cargo test ycbust_contract`
+//!   runs the whole suite.
+//! - Pin format / layout / enum shape. Do NOT pin implementation behavior
+//!   (e.g. download ordering) — that's upstream's business.
+//! - Live network coverage lives in `ycbust_s3_integration.rs` behind the
+//!   `ycbust-s3` feature, `#[ignore]`d by default.
+
+use std::path::Path;
+use ycbust::{
+    get_tgz_url, object_mesh_path, object_texture_path, validate_objects, DownloadOptions,
+    ObjectValidation, Subset, YcbError, GOOGLE_16K_MESH_RELATIVE, GOOGLE_16K_TEXTURE_RELATIVE,
+    REPRESENTATIVE_OBJECTS, TBP_SIMILAR_OBJECTS, TBP_STANDARD_OBJECTS,
+};
+
+// -----------------------------------------------------------------------------
+// Subset enum
+// -----------------------------------------------------------------------------
+
+#[test]
+fn ycbust_contract_subset_variants_present() {
+    // bevy-sensor routes user config through these variants; removing any of
+    // them is a breaking change for downstream callers of `ycb::download_models`.
+    let _ = Subset::Representative;
+    let _ = Subset::TbpStandard;
+    let _ = Subset::TbpSimilar;
+    let _ = Subset::All;
+    // `Subset::Ten` is deprecated upstream but still exists; bevy-sensor no
+    // longer re-exports it and no longer depends on the variant.
+}
+
+#[test]
+fn ycbust_contract_subset_default_is_representative() {
+    assert_eq!(Subset::default(), Subset::Representative);
+}
+
+// -----------------------------------------------------------------------------
+// Object constants — content is part of the contract because bevy-sensor's
+// `models_exist()` and prerender fixtures hardcode specific object ids.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn ycbust_contract_representative_objects_content_stable() {
+    assert_eq!(
+        REPRESENTATIVE_OBJECTS,
+        &["003_cracker_box", "004_sugar_box", "005_tomato_soup_can"],
+    );
+}
+
+#[test]
+fn ycbust_contract_tbp_standard_objects_shape_stable() {
+    assert_eq!(TBP_STANDARD_OBJECTS.len(), 10);
+    // Spot-check TBP canonical entries.
+    assert!(TBP_STANDARD_OBJECTS.contains(&"025_mug"));
+    assert!(TBP_STANDARD_OBJECTS.contains(&"011_banana"));
+    assert!(TBP_STANDARD_OBJECTS.contains(&"058_golf_ball"));
+}
+
+#[test]
+fn ycbust_contract_tbp_similar_objects_shape_stable() {
+    assert_eq!(TBP_SIMILAR_OBJECTS.len(), 10);
+    assert!(TBP_SIMILAR_OBJECTS.contains(&"003_cracker_box"));
+    assert!(TBP_SIMILAR_OBJECTS.contains(&"051_large_clamp"));
+}
+
+// -----------------------------------------------------------------------------
+// URL / path helpers — bevy-sensor's `render.rs` and `download_objects`
+// construct paths from these. Breaking the layout breaks asset loading.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn ycbust_contract_get_tgz_url_google_16k_format() {
+    // bevy-sensor's `ycb::download_objects` passes the result of this call
+    // straight to `download_file`. Host + `google/{id}_google_16k.tgz` is
+    // the shape we rely on.
+    let url = get_tgz_url("003_cracker_box", "google_16k");
+    assert_eq!(
+        url,
+        "https://ycb-benchmarks.s3.amazonaws.com/data/google/003_cracker_box_google_16k.tgz",
+    );
+}
+
+#[test]
+fn ycbust_contract_object_mesh_path_layout() {
+    // `render.rs` loads `{object_dir}/google_16k/textured.obj` directly. This
+    // helper MUST produce the same relative layout so `models_exist` and the
+    // renderer agree.
+    let root = Path::new("/tmp/ycb");
+    assert_eq!(
+        object_mesh_path(root, "003_cracker_box"),
+        root.join("003_cracker_box")
+            .join("google_16k")
+            .join("textured.obj"),
+    );
+}
+
+#[test]
+fn ycbust_contract_object_texture_path_layout() {
+    let root = Path::new("/tmp/ycb");
+    assert_eq!(
+        object_texture_path(root, "003_cracker_box"),
+        root.join("003_cracker_box")
+            .join("google_16k")
+            .join("texture_map.png"),
+    );
+}
+
+// -----------------------------------------------------------------------------
+// DownloadOptions defaults — bevy-sensor's `download_models` assumes these
+// defaults (full=false so only google_16k is fetched; delete_archives=true so
+// we don't leak .tgz files into the YCB tree).
+// -----------------------------------------------------------------------------
+
+#[test]
+fn ycbust_contract_download_options_defaults() {
+    let opts = DownloadOptions::default();
+    assert!(!opts.overwrite, "overwrite default must be false");
+    assert!(
+        !opts.full,
+        "full default must be false — bevy-sensor only consumes google_16k"
+    );
+    assert!(opts.show_progress, "show_progress default must be true");
+    assert!(opts.delete_archives, "delete_archives default must be true");
+    // v0.4.0 fields — behavior-preserving defaults.
+    assert_eq!(
+        opts.concurrency, 1,
+        "concurrency default must be 1 (serial) for compatibility"
+    );
+    assert!(
+        opts.verify_integrity,
+        "verify_integrity default must be true — correctness over speed"
+    );
+}
+
+#[test]
+fn ycbust_contract_download_options_is_non_exhaustive() {
+    // `#[non_exhaustive]` on DownloadOptions means struct-literal construction
+    // from outside the crate fails to compile. The compile-time signal is
+    // what protects us — this runtime test just pins the construction path
+    // we rely on (Default + field override).
+    let mut opts = DownloadOptions::default();
+    opts.concurrency = 4;
+    opts.verify_integrity = false;
+    assert_eq!(opts.concurrency, 4);
+    assert!(!opts.verify_integrity);
+}
+
+// -----------------------------------------------------------------------------
+// validate_objects — bevy-sensor plans to delegate `models_exist` to this
+// helper. Pin the shape so a field rename is caught here first.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn ycbust_contract_validate_objects_on_empty_dir() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let results = validate_objects(dir.path(), REPRESENTATIVE_OBJECTS);
+    assert_eq!(results.len(), REPRESENTATIVE_OBJECTS.len());
+    for r in &results {
+        assert!(!r.mesh_present);
+        assert!(!r.texture_present);
+        assert!(!r.is_complete());
+    }
+}
+
+#[test]
+fn ycbust_contract_validate_objects_detects_complete_object() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // Materialize both mesh and texture for one representative object.
+    let mesh = object_mesh_path(dir.path(), "003_cracker_box");
+    let tex = object_texture_path(dir.path(), "003_cracker_box");
+    std::fs::create_dir_all(mesh.parent().unwrap()).unwrap();
+    std::fs::write(&mesh, b"").unwrap();
+    std::fs::write(&tex, b"").unwrap();
+
+    let results = validate_objects(dir.path(), &["003_cracker_box"]);
+    assert_eq!(results.len(), 1);
+    assert!(results[0].is_complete());
+    assert_eq!(results[0].name, "003_cracker_box");
+}
+
+#[test]
+fn ycbust_contract_object_validation_public_fields() {
+    // Explicit type assertion that the public shape we code against still holds.
+    let v = ObjectValidation {
+        name: "003_cracker_box".to_string(),
+        mesh_present: true,
+        texture_present: true,
+    };
+    assert!(v.is_complete());
+    let partial = ObjectValidation {
+        name: "004_sugar_box".to_string(),
+        mesh_present: true,
+        texture_present: false,
+    };
+    assert!(!partial.is_complete());
+}
+
+// -----------------------------------------------------------------------------
+// Signature pins — compile-only. These evaluate the ycbust functions that
+// bevy-sensor wraps, so a breaking signature change fails here (and at the
+// real call sites in `src/lib.rs`).
+// -----------------------------------------------------------------------------
+
+#[test]
+fn ycbust_contract_download_ycb_is_callable() {
+    // Build the future but never poll it — network call never happens, but
+    // the signature is type-checked by construction.
+    let fut = ycbust::download_ycb(
+        Subset::Representative,
+        Path::new("/nonexistent-path-for-type-check-only"),
+        DownloadOptions::default(),
+    );
+    drop(fut);
+}
+
+#[test]
+fn ycbust_contract_extract_tgz_is_callable() {
+    // Call on a path we know doesn't exist; we only care that it returns an
+    // error rather than failing to compile.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let err = ycbust::extract_tgz(
+        &dir.path().join("does_not_exist.tgz"),
+        dir.path(),
+        false,
+    );
+    assert!(err.is_err());
+}
+
+#[test]
+fn ycbust_contract_download_objects_is_callable() {
+    // Upstream `download_objects` (shipped in v0.3.3) — bevy-sensor's
+    // `ycb::download_objects` wrapper is a thin delegate over this.
+    let fut = ycbust::download_objects(
+        &["003_cracker_box"],
+        Path::new("/nonexistent-path-for-type-check-only"),
+        DownloadOptions::default(),
+    );
+    drop(fut);
+}
+
+// -----------------------------------------------------------------------------
+// GOOGLE_16K path consts (v0.3.3) — `render.rs` joins these with per-object
+// directories in place of hardcoded strings. Literal values are part of the
+// contract: if upstream switches to `google_16k\\textured.obj` on any platform
+// we need to know immediately, not at asset-load time.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn ycbust_contract_google_16k_mesh_relative_literal() {
+    assert_eq!(GOOGLE_16K_MESH_RELATIVE, "google_16k/textured.obj");
+}
+
+#[test]
+fn ycbust_contract_google_16k_texture_relative_literal() {
+    assert_eq!(GOOGLE_16K_TEXTURE_RELATIVE, "google_16k/texture_map.png");
+}
+
+#[test]
+fn ycbust_contract_google_16k_consts_compose_with_object_dir() {
+    // The whole point of the consts: `object_dir.join(MESH_RELATIVE)` must
+    // yield the same path `object_mesh_path(root, id)` produces.
+    let root = Path::new("/tmp/ycb");
+    let per_object = root.join("003_cracker_box");
+    assert_eq!(
+        per_object.join(GOOGLE_16K_MESH_RELATIVE),
+        object_mesh_path(root, "003_cracker_box"),
+    );
+    assert_eq!(
+        per_object.join(GOOGLE_16K_TEXTURE_RELATIVE),
+        object_texture_path(root, "003_cracker_box"),
+    );
+}
+
+// -----------------------------------------------------------------------------
+// YcbError (v0.4.0) — bevy-sensor maps these into `RenderError` in follow-up
+// work. Pinning the match shape here means a future variant rename or removal
+// fails in this suite before it reaches the mapping code.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn ycbust_contract_error_variants_matchable() {
+    // Cover every concrete variant we rely on distinguishing. `YcbError` is
+    // `#[non_exhaustive]`, so the wildcard arm is required to absorb variants
+    // added upstream without breaking us — but removing one of these named
+    // arms *will* fail to compile here.
+    fn classify(err: YcbError) -> &'static str {
+        match err {
+            YcbError::Network(_) => "network",
+            YcbError::HttpStatus { .. } => "http_status",
+            YcbError::Extraction { .. } => "extraction",
+            YcbError::Io(_) => "io",
+            YcbError::Integrity { .. } => "integrity",
+            YcbError::InvalidResponse(_) => "invalid_response",
+            YcbError::UnsafeArchive(_) => "unsafe_archive",
+            YcbError::Other(_) => "other",
+            _ => "unknown_non_exhaustive",
+        }
+    }
+    let http = YcbError::HttpStatus {
+        status: 404,
+        url: "https://example.com".into(),
+    };
+    assert_eq!(classify(http), "http_status");
+
+    let integrity = YcbError::Integrity {
+        path: "/tmp/foo.tgz".into(),
+        reason: "expected 1024, got 512".into(),
+    };
+    assert_eq!(classify(integrity), "integrity");
+}
+
+#[test]
+fn ycbust_contract_error_from_and_into_anyhow() {
+    // Bidirectional conversion keeps anyhow-using consumers working.
+    let y = YcbError::HttpStatus {
+        status: 404,
+        url: "https://example.com".into(),
+    };
+    let a: anyhow::Error = y.into();
+    assert!(a.to_string().contains("404"));
+}
+
+#[test]
+fn ycbust_contract_result_alias_present() {
+    // `ycbust::Result<T>` should alias to `Result<T, YcbError>`.
+    fn _check(_r: ycbust::Result<()>) {}
+}
+
+// -----------------------------------------------------------------------------
+// Blocking wrappers (v0.4.0, `blocking` feature) — bevy-sensor's `prerender`
+// binary uses these to avoid spinning up a throwaway Tokio runtime. They're
+// part of this crate's hard dependency surface now.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn ycbust_contract_blocking_wrappers_present() {
+    // Compile-check: both wrappers exist with the expected signatures.
+    let _f1: fn(Subset, &Path, DownloadOptions) -> ycbust::Result<()> =
+        ycbust::blocking::download_ycb_blocking;
+    let _f2: fn(&[&str], &Path, DownloadOptions) -> ycbust::Result<()> =
+        ycbust::blocking::download_objects_blocking;
+}
+
+#[test]
+fn ycbust_contract_blocking_download_objects_empty_slice_is_noop() {
+    // Empty slice should no-op without hitting the network. Also exercises
+    // the runtime-construction path in the blocking wrapper.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let result = ycbust::blocking::download_objects_blocking(
+        &[],
+        dir.path(),
+        DownloadOptions::default(),
+    );
+    assert!(result.is_ok());
+}

--- a/tests/ycbust_contract.rs
+++ b/tests/ycbust_contract.rs
@@ -228,11 +228,7 @@ fn ycbust_contract_extract_tgz_is_callable() {
     // Call on a path we know doesn't exist; we only care that it returns an
     // error rather than failing to compile.
     let dir = tempfile::tempdir().expect("tempdir");
-    let err = ycbust::extract_tgz(
-        &dir.path().join("does_not_exist.tgz"),
-        dir.path(),
-        false,
-    );
+    let err = ycbust::extract_tgz(&dir.path().join("does_not_exist.tgz"), dir.path(), false);
     assert!(err.is_err());
 }
 
@@ -356,10 +352,7 @@ fn ycbust_contract_blocking_download_objects_empty_slice_is_noop() {
     // Empty slice should no-op without hitting the network. Also exercises
     // the runtime-construction path in the blocking wrapper.
     let dir = tempfile::tempdir().expect("tempdir");
-    let result = ycbust::blocking::download_objects_blocking(
-        &[],
-        dir.path(),
-        DownloadOptions::default(),
-    );
+    let result =
+        ycbust::blocking::download_objects_blocking(&[], dir.path(), DownloadOptions::default());
     assert!(result.is_ok());
 }

--- a/tests/ycbust_network_smoke.rs
+++ b/tests/ycbust_network_smoke.rs
@@ -1,0 +1,126 @@
+//! ycbust network smoke tests.
+//!
+//! These hit the real YCB S3 endpoint (`https://ycb-benchmarks.s3.amazonaws.com`)
+//! and download actual archives. All tests here are `#[ignore]`d so `cargo test`
+//! never runs them by default — CI and offline builds stay fast and hermetic.
+//!
+//! Running:
+//!   cargo test --test ycbust_network_smoke -- --ignored --nocapture
+//!
+//! What this guards:
+//! - `ycbust::blocking::download_ycb_blocking` actually completes end-to-end
+//!   (the path `prerender` binary now takes after the v0.4.x migration).
+//! - `DownloadOptions::concurrency > 1` is faster than serial on a cold cache.
+//! - Extracted mesh layout still matches the contract (`GOOGLE_16K_*` consts).
+//!
+//! Failures here after a ycbust bump mean: coordinate with
+//! <https://github.com/Agentic-Insights/ycbust>.
+
+use std::time::Instant;
+use ycbust::{
+    blocking::download_ycb_blocking, object_mesh_path, object_texture_path, DownloadOptions,
+    Subset, REPRESENTATIVE_OBJECTS, TBP_STANDARD_OBJECTS,
+};
+
+fn silent_options(concurrency: usize) -> DownloadOptions {
+    let mut opts = DownloadOptions::default();
+    opts.show_progress = false;
+    opts.concurrency = concurrency;
+    opts
+}
+
+fn assert_subset_present<P: AsRef<std::path::Path>>(dir: P, ids: &[&str]) {
+    let dir = dir.as_ref();
+    for id in ids {
+        let mesh = object_mesh_path(dir, id);
+        let tex = object_texture_path(dir, id);
+        assert!(mesh.exists(), "{id}: missing mesh at {}", mesh.display());
+        assert!(tex.exists(), "{id}: missing texture at {}", tex.display());
+    }
+}
+
+#[test]
+#[ignore = "hits real network; run with --ignored --nocapture"]
+fn ycbust_network_smoke_blocking_download_representative() {
+    // The exact path `prerender` takes post-migration: blocking wrapper +
+    // default options. Cold cache, no-op second call.
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    let start = Instant::now();
+    download_ycb_blocking(
+        Subset::Representative,
+        dir.path(),
+        silent_options(1),
+    )
+    .expect("initial download failed");
+    let first = start.elapsed();
+
+    assert_subset_present(dir.path(), REPRESENTATIVE_OBJECTS);
+    println!("representative cold download (concurrency=1): {first:?}");
+
+    // Second call should short-circuit on extracted-mesh detection — no
+    // re-download. This validates the resume path we rely on.
+    let start = Instant::now();
+    download_ycb_blocking(
+        Subset::Representative,
+        dir.path(),
+        silent_options(1),
+    )
+    .expect("warm download failed");
+    let warm = start.elapsed();
+    println!("representative warm resume (concurrency=1): {warm:?}");
+
+    // Warm resume should be dramatically faster. 10x is conservative — a
+    // warm run does only the short-circuit checks, no HEAD/GET.
+    assert!(
+        warm * 10 < first,
+        "warm resume ({warm:?}) not meaningfully faster than cold ({first:?}) — resume check may be broken"
+    );
+}
+
+#[test]
+#[ignore = "hits real network; downloads ~10 YCB archives; run with --ignored --nocapture"]
+fn ycbust_network_smoke_parallel_beats_serial_tbp_standard() {
+    // TBP standard = 10 objects, enough work that parallel concurrency
+    // should visibly win over serial. Each subset into its own tempdir
+    // so neither run benefits from the other's cache.
+    let serial_dir = tempfile::tempdir().expect("tempdir serial");
+    let parallel_dir = tempfile::tempdir().expect("tempdir parallel");
+
+    let start = Instant::now();
+    download_ycb_blocking(
+        Subset::TbpStandard,
+        serial_dir.path(),
+        silent_options(1),
+    )
+    .expect("serial download failed");
+    let serial = start.elapsed();
+    assert_subset_present(serial_dir.path(), TBP_STANDARD_OBJECTS);
+
+    let start = Instant::now();
+    download_ycb_blocking(
+        Subset::TbpStandard,
+        parallel_dir.path(),
+        silent_options(4),
+    )
+    .expect("parallel download failed");
+    let parallel = start.elapsed();
+    assert_subset_present(parallel_dir.path(), TBP_STANDARD_OBJECTS);
+
+    println!("tbp_standard serial   (concurrency=1): {serial:?}");
+    println!("tbp_standard parallel (concurrency=4): {parallel:?}");
+    println!(
+        "speedup: {:.2}x",
+        serial.as_secs_f64() / parallel.as_secs_f64()
+    );
+
+    // Soft check — don't fail on pure noise, but warn if parallel isn't at
+    // least marginally faster. Network variance can legitimately cause a
+    // ~10% regression on any given run.
+    if parallel >= serial {
+        eprintln!(
+            "WARN: parallel ({parallel:?}) not faster than serial ({serial:?}) — \
+             network noise or a concurrency regression upstream"
+        );
+    }
+}

--- a/tests/ycbust_network_smoke.rs
+++ b/tests/ycbust_network_smoke.rs
@@ -47,12 +47,8 @@ fn ycbust_network_smoke_blocking_download_representative() {
     let dir = tempfile::tempdir().expect("tempdir");
 
     let start = Instant::now();
-    download_ycb_blocking(
-        Subset::Representative,
-        dir.path(),
-        silent_options(1),
-    )
-    .expect("initial download failed");
+    download_ycb_blocking(Subset::Representative, dir.path(), silent_options(1))
+        .expect("initial download failed");
     let first = start.elapsed();
 
     assert_subset_present(dir.path(), REPRESENTATIVE_OBJECTS);
@@ -61,12 +57,8 @@ fn ycbust_network_smoke_blocking_download_representative() {
     // Second call should short-circuit on extracted-mesh detection — no
     // re-download. This validates the resume path we rely on.
     let start = Instant::now();
-    download_ycb_blocking(
-        Subset::Representative,
-        dir.path(),
-        silent_options(1),
-    )
-    .expect("warm download failed");
+    download_ycb_blocking(Subset::Representative, dir.path(), silent_options(1))
+        .expect("warm download failed");
     let warm = start.elapsed();
     println!("representative warm resume (concurrency=1): {warm:?}");
 
@@ -88,22 +80,14 @@ fn ycbust_network_smoke_parallel_beats_serial_tbp_standard() {
     let parallel_dir = tempfile::tempdir().expect("tempdir parallel");
 
     let start = Instant::now();
-    download_ycb_blocking(
-        Subset::TbpStandard,
-        serial_dir.path(),
-        silent_options(1),
-    )
-    .expect("serial download failed");
+    download_ycb_blocking(Subset::TbpStandard, serial_dir.path(), silent_options(1))
+        .expect("serial download failed");
     let serial = start.elapsed();
     assert_subset_present(serial_dir.path(), TBP_STANDARD_OBJECTS);
 
     let start = Instant::now();
-    download_ycb_blocking(
-        Subset::TbpStandard,
-        parallel_dir.path(),
-        silent_options(4),
-    )
-    .expect("parallel download failed");
+    download_ycb_blocking(Subset::TbpStandard, parallel_dir.path(), silent_options(4))
+        .expect("parallel download failed");
     let parallel = start.elapsed();
     assert_subset_present(parallel_dir.path(), TBP_STANDARD_OBJECTS);
 

--- a/tests/ycbust_s3_integration.rs
+++ b/tests/ycbust_s3_integration.rs
@@ -1,0 +1,106 @@
+//! ycbust S3 integration tests.
+//!
+//! Gated behind the `ycbust-s3` Cargo feature (which enables `ycbust/s3`).
+//! These exist so the S3 streaming path upstream stays exercised from
+//! bevy-sensor's side — bevy-sensor does not use S3 at runtime, but neocortx
+//! deployments may, and we want a canary if the upstream surface drifts.
+//!
+//! Conventions:
+//! - `ycbust_s3_contract_*` — offline compile/parse-level tests. Run by default
+//!   when `--features ycbust-s3` is set.
+//! - `ycbust_s3_live_*` — live tests hitting a real bucket. `#[ignore]`d so
+//!   they never run on CI by accident. Opt in with
+//!   `cargo test --features ycbust-s3 -- --ignored ycbust_s3_live`
+//!   and set `BEVY_SENSOR_S3_TEST_BUCKET=my-bucket`.
+//!
+//! Running:
+//!   cargo test --features ycbust-s3 ycbust_s3_contract
+//!   cargo test --features ycbust-s3 -- --ignored ycbust_s3_live
+
+#![cfg(feature = "ycbust-s3")]
+
+use ycbust::s3::S3Destination;
+
+// -----------------------------------------------------------------------------
+// Offline contract — parse / constructor behavior. No network.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn ycbust_s3_contract_destination_parses_bucket_and_prefix() {
+    let dest = S3Destination::from_url("s3://my-bucket/ycb-data/").expect("parse");
+    assert_eq!(dest.bucket, "my-bucket");
+    assert_eq!(dest.prefix, "ycb-data/");
+    assert_eq!(dest.region, "us-east-1");
+}
+
+#[test]
+fn ycbust_s3_contract_destination_normalizes_missing_trailing_slash() {
+    let dest = S3Destination::from_url("s3://my-bucket/ycb-data").expect("parse");
+    assert_eq!(dest.prefix, "ycb-data/");
+}
+
+#[test]
+fn ycbust_s3_contract_destination_accepts_bucket_root() {
+    let dest = S3Destination::from_url("s3://my-bucket/").expect("parse");
+    assert_eq!(dest.bucket, "my-bucket");
+    assert_eq!(dest.prefix, "");
+}
+
+#[test]
+fn ycbust_s3_contract_destination_rejects_non_s3_scheme() {
+    assert!(S3Destination::from_url("https://my-bucket/").is_err());
+}
+
+#[test]
+fn ycbust_s3_contract_destination_rejects_empty_bucket() {
+    assert!(S3Destination::from_url("s3://").is_err());
+}
+
+#[test]
+fn ycbust_s3_contract_destination_with_region_is_chainable() {
+    let dest = S3Destination::from_url("s3://my-bucket/p/")
+        .expect("parse")
+        .with_region("us-west-2");
+    assert_eq!(dest.region, "us-west-2");
+}
+
+#[test]
+fn ycbust_s3_contract_destination_full_path_joins_prefix() {
+    let dest = S3Destination::from_url("s3://b/ycb/").unwrap();
+    assert_eq!(dest.full_path("003_cracker_box.tgz"), "ycb/003_cracker_box.tgz");
+}
+
+#[test]
+fn ycbust_s3_contract_destination_to_url_roundtrips_prefix() {
+    let dest = S3Destination::from_url("s3://b/ycb/").unwrap();
+    assert_eq!(dest.to_url(), "s3://b/ycb/");
+}
+
+// -----------------------------------------------------------------------------
+// Live integration — opt-in, requires AWS credentials + a test bucket.
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires real S3 bucket + AWS creds; set BEVY_SENSOR_S3_TEST_BUCKET"]
+async fn ycbust_s3_live_download_representative_to_bucket() {
+    use ycbust::s3::download_ycb_to_s3;
+    use ycbust::{DownloadOptions, Subset};
+
+    let bucket = std::env::var("BEVY_SENSOR_S3_TEST_BUCKET")
+        .expect("set BEVY_SENSOR_S3_TEST_BUCKET to an AWS bucket you own");
+    let dest =
+        S3Destination::from_url(&format!("s3://{}/bevy-sensor-ycbust-live/", bucket)).unwrap();
+
+    download_ycb_to_s3(Subset::Representative, dest, DownloadOptions::default(), None)
+        .await
+        .expect("live S3 upload of representative subset");
+}
+
+#[tokio::test]
+#[ignore = "requires real AWS creds; verifies ycbust can load them end-to-end"]
+async fn ycbust_s3_live_credentials_loadable() {
+    let id = ycbust::s3::check_aws_credentials(None)
+        .await
+        .expect("AWS credentials must resolve via default chain");
+    assert!(id.contains("AWS credentials"));
+}

--- a/tests/ycbust_s3_integration.rs
+++ b/tests/ycbust_s3_integration.rs
@@ -67,7 +67,10 @@ fn ycbust_s3_contract_destination_with_region_is_chainable() {
 #[test]
 fn ycbust_s3_contract_destination_full_path_joins_prefix() {
     let dest = S3Destination::from_url("s3://b/ycb/").unwrap();
-    assert_eq!(dest.full_path("003_cracker_box.tgz"), "ycb/003_cracker_box.tgz");
+    assert_eq!(
+        dest.full_path("003_cracker_box.tgz"),
+        "ycb/003_cracker_box.tgz"
+    );
 }
 
 #[test]
@@ -91,9 +94,14 @@ async fn ycbust_s3_live_download_representative_to_bucket() {
     let dest =
         S3Destination::from_url(&format!("s3://{}/bevy-sensor-ycbust-live/", bucket)).unwrap();
 
-    download_ycb_to_s3(Subset::Representative, dest, DownloadOptions::default(), None)
-        .await
-        .expect("live S3 upload of representative subset");
+    download_ycb_to_s3(
+        Subset::Representative,
+        dest,
+        DownloadOptions::default(),
+        None,
+    )
+    .await
+    .expect("live S3 upload of representative subset");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes the migration path from [#61](https://github.com/killerapp/bevy-sensor/issues/61). Picks up the coordinated `ycbust` v0.4.0 breaking release, collapses the wrappers it enables, switches `prerender` off its throwaway tokio runtime, and adds a labeled contract-test suite so we coordinate cleanly with the ycbust team on future bumps.

## Summary

- `ycbust = "0.3"` → `{ version = "0.4.0", features = ["blocking"] }`. v0.4.0 ships typed `YcbError`, `DownloadOptions::concurrency`, `DownloadOptions::verify_integrity`, and the `blocking` feature — all four of our P0/P1 asks from #61.
- `ycb::download_objects` shrinks from a 20-line loop to a 3-line delegate over `ycbust::download_objects` (upstream v0.3.3).
- `render.rs` drops 8 hardcoded `"google_16k/..."` strings for `GOOGLE_16K_MESH_RELATIVE` / `GOOGLE_16K_TEXTURE_RELATIVE`.
- `prerender` binary calls `ycbust::blocking::download_ycb_blocking(...)` in place of two `tokio::runtime::Runtime::new()` sites.
- Removed `TEN_OBJECTS` re-export (deprecated since v0.3.0); added `TBP_SIMILAR_OBJECTS` alongside the standard set.

## Test additions

- `tests/ycbust_contract.rs` — **24 offline tests**, `ycbust_contract_*` prefix. Header comment routes future failures back to `Agentic-Insights/ycbust`. Pins: subset variants, object-set contents, URL format, path layout, `DownloadOptions` defaults (incl. new v0.4 fields), `YcbError` exhaustive matchability with `#[non_exhaustive]` fallthrough, bidirectional `YcbError` ↔ `anyhow::Error`, `GOOGLE_16K_*` compose invariant, blocking-wrapper signatures, `download_objects` signature.
- `tests/ycbust_s3_integration.rs` — behind `ycbust-s3` feature. 8 offline `ycbust_s3_contract_*` + 2 `#[ignore]`d `ycbust_s3_live_*` (opt-in via `BEVY_SENSOR_S3_TEST_BUCKET`).

## Breaking change (downstream)

`bevy_sensor::DownloadOptions` (re-exported from ycbust) is now `#[non_exhaustive]`. Consumers constructing it via struct literal must switch:

```rust
// Before
let options = DownloadOptions { overwrite: false, full: false, show_progress: true, delete_archives: true };

// After
let mut options = DownloadOptions::default();
options.overwrite = false;
// or: DownloadOptions { overwrite: false, ..Default::default() }
```

Re-exported `ycbust` function return types change from `anyhow::Result<T>` to `Result<T, ycbust::YcbError>`. Consumers using `?` through an anyhow chain keep working via `From<YcbError> for anyhow::Error`.

## Test plan

- [x] `cargo test --lib --tests` → 83 lib + 8 + 2 + 24 contract = **117 pass**, 1 pre-existing ignored
- [x] `cargo test --features ycbust-s3 --test ycbust_s3_integration` → 8 pass, 2 live tests correctly ignored
- [x] `cargo clippy --all-targets` clean (default and `--features ycbust-s3`)
- [ ] Visual verify `prerender` binary downloads representative set via `blocking::download_ycb_blocking` on a clean `/tmp/ycb`

## Follow-ups (tracked upstream)

- [`Agentic-Insights/ycbust#22`](https://github.com/Agentic-Insights/ycbust/issues/22) — P2 structured progress callback
- [`Agentic-Insights/ycbust#23`](https://github.com/Agentic-Insights/ycbust/issues/23) — P2 `ycbust::meta` TBP metadata module
- Offered to mirror our `ycbust_contract_*` tests into ycbust's `tests/` as upstream regression guards — list in [#61 comment](https://github.com/killerapp/bevy-sensor/issues/61#issuecomment-4307763015)

🤖 Generated with [Claude Code](https://claude.com/claude-code)