### PR TITLE
feat(render): PersistentRenderer for per-step feedback loops

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "effortLevel": "xhigh"
+}

--- a/examples/persistent_per_step.rs
+++ b/examples/persistent_per_step.rs
@@ -66,7 +66,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if !object_dir.exists() {
         eprintln!("Object directory not found: {object_dir:?}");
-        eprintln!("Run: bevy_sensor::ycb::download_models(\"/tmp/ycb\", Subset::Representative).await?;");
+        eprintln!(
+            "Run: bevy_sensor::ycb::download_models(\"/tmp/ycb\", Subset::Representative).await?;"
+        );
         return Err("Object directory not found".into());
     }
 
@@ -140,10 +142,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     renderer.close();
 
     println!();
-    println!("Speedup vs render_to_buffer per call: {:.2}x",
-        baseline_per_step / persistent_per_step);
-    println!("Speedup vs fresh RenderSession per call: {:.2}x",
-        session_per_step / persistent_per_step);
+    println!(
+        "Speedup vs render_to_buffer per call: {:.2}x",
+        baseline_per_step / persistent_per_step
+    );
+    println!(
+        "Speedup vs fresh RenderSession per call: {:.2}x",
+        session_per_step / persistent_per_step
+    );
 
     Ok(())
 }

--- a/examples/persistent_per_step.rs
+++ b/examples/persistent_per_step.rs
@@ -1,0 +1,149 @@
+//! Example: Per-step persistent rendering for surface-policy feedback loops.
+//!
+//! Closes issue #65. Demonstrates the `PersistentRenderer` API and benchmarks
+//! it against the two existing rendering paths to give a concrete speedup
+//! number for downstream consumers (neocortx surface-policy port).
+//!
+//! Usage:
+//! ```sh
+//! cargo run --example persistent_per_step --release
+//! cargo run --example persistent_per_step --release -- --steps 100 --object 003_cracker_box
+//! ```
+//!
+//! Compares three paths over `STEPS` single-viewpoint renders against one
+//! object:
+//!
+//!   1. `render_to_buffer` per call          — fresh App every time (worst).
+//!   2. Fresh `RenderSession` per call       — current best for one-off shape.
+//!   3. `PersistentRenderer::render` per call — scene held loaded (proposed).
+//!
+//! For a surface-policy episode (50–200 motor steps × 30 episodes × 10 objs),
+//! the per-step path dominates wall-clock — this is the case #65 was filed for.
+
+use bevy_sensor::{
+    batch::BatchRenderRequest, generate_viewpoints, render_to_buffer, BatchRenderConfig,
+    ObjectRotation, PersistentRenderer, RenderConfig, RenderSession, ViewpointConfig,
+};
+use std::path::PathBuf;
+use std::time::Instant;
+
+fn parse_args() -> (usize, String) {
+    let mut steps = 50_usize;
+    let mut object = "003_cracker_box".to_string();
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--steps" => {
+                if let Some(v) = args.next() {
+                    steps = v.parse().unwrap_or(steps);
+                }
+            }
+            "--object" => {
+                if let Some(v) = args.next() {
+                    object = v;
+                }
+            }
+            _ => {}
+        }
+    }
+    (steps, object)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let (steps, object_id) = parse_args();
+    let object_dir = PathBuf::from(format!("/tmp/ycb/{object_id}"));
+    let render_config = RenderConfig::tbp_default();
+
+    println!("PersistentRenderer per-step throughput bench (issue #65)");
+    println!("=========================================================");
+    println!("  Object:     {object_id}");
+    println!(
+        "  Resolution: {}x{}",
+        render_config.width, render_config.height
+    );
+    println!("  Steps:      {steps}");
+    println!();
+
+    if !object_dir.exists() {
+        eprintln!("Object directory not found: {object_dir:?}");
+        eprintln!("Run: bevy_sensor::ycb::download_models(\"/tmp/ycb\", Subset::Representative).await?;");
+        return Err("Object directory not found".into());
+    }
+
+    let viewpoint_config = ViewpointConfig {
+        radius: 0.5,
+        yaw_count: 8,
+        pitch_angles_deg: vec![-30.0, 0.0, 30.0],
+    };
+    let viewpoints = generate_viewpoints(&viewpoint_config);
+    let rotation = ObjectRotation::identity();
+
+    let viewpoint_for = |i: usize| viewpoints[i % viewpoints.len()];
+
+    // ---- Baseline 1: render_to_buffer per call (fresh App each time) ----
+    println!("[1/3] render_to_buffer per call (fresh App per step)");
+    let t0 = Instant::now();
+    for i in 0..steps {
+        let vp = viewpoint_for(i);
+        let _ = render_to_buffer(&object_dir, &vp, &rotation, &render_config)?;
+    }
+    let baseline = t0.elapsed();
+    let baseline_per_step = baseline.as_secs_f64() * 1000.0 / steps as f64;
+    println!(
+        "      total {:.1} s, per-step {:.1} ms",
+        baseline.as_secs_f64(),
+        baseline_per_step
+    );
+
+    // ---- Baseline 2: fresh RenderSession per call ----
+    println!("[2/3] fresh RenderSession per call");
+    let t1 = Instant::now();
+    for i in 0..steps {
+        let vp = viewpoint_for(i);
+        let mut session = RenderSession::new(&render_config)?;
+        let _ = session.render(&[BatchRenderRequest {
+            object_dir: object_dir.clone(),
+            viewpoint: vp,
+            object_rotation: rotation.clone(),
+            render_config: render_config.clone(),
+        }])?;
+    }
+    let session_per_call = t1.elapsed();
+    let session_per_step = session_per_call.as_secs_f64() * 1000.0 / steps as f64;
+    println!(
+        "      total {:.1} s, per-step {:.1} ms",
+        session_per_call.as_secs_f64(),
+        session_per_step
+    );
+
+    // ---- The new path: PersistentRenderer ----
+    println!("[3/3] PersistentRenderer (scene held loaded)");
+    let t2 = Instant::now();
+    let mut renderer = PersistentRenderer::new(&object_dir, &render_config)?;
+    let init = t2.elapsed();
+    let t3 = Instant::now();
+    for i in 0..steps {
+        let vp = viewpoint_for(i);
+        let _ = renderer.render(&vp, &rotation)?;
+    }
+    let persistent_steps = t3.elapsed();
+    let persistent_per_step = persistent_steps.as_secs_f64() * 1000.0 / steps as f64;
+    println!(
+        "      init {:.0} ms, total {:.1} s, per-step {:.1} ms",
+        init.as_secs_f64() * 1000.0,
+        persistent_steps.as_secs_f64(),
+        persistent_per_step
+    );
+
+    // Touch the API to keep symbol used and demonstrate explicit teardown.
+    let _ = BatchRenderConfig::default();
+    renderer.close();
+
+    println!();
+    println!("Speedup vs render_to_buffer per call: {:.2}x",
+        baseline_per_step / persistent_per_step);
+    println!("Speedup vs fresh RenderSession per call: {:.2}x",
+        session_per_step / persistent_per_step);
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -811,9 +811,11 @@ pub fn render_all_viewpoints(
 /// Render with model caching support for efficient multi-viewpoint rendering.
 ///
 /// This function tracks which models have been loaded and provides performance
-/// insights. The current batch API is a queue-oriented wrapper, not a persistent
-/// renderer, so this function and `render_to_buffer()` use the same underlying
-/// headless app-per-render path today.
+/// insights. It still spins up a fresh headless `App` per call. For workloads
+/// that render many frames against the same object/config, prefer
+/// `RenderSession` (homogeneous batches per episode) or `PersistentRenderer`
+/// (one frame per call, scene held loaded across calls — built for surface-
+/// policy feedback loops).
 ///
 /// # Arguments
 /// * `object_dir` - Path to YCB object directory
@@ -936,6 +938,13 @@ pub use batch::{
 /// Persistent batch render session. See the module docs in `render::RenderSession`
 /// for lifetime, thread-affinity, and config-invariance guarantees.
 pub use render::RenderSession;
+
+/// Per-step persistent renderer for feedback loops. See the module docs in
+/// `render::PersistentRenderer` for lifetime, thread-affinity, and
+/// object/config-invariance guarantees. Built for the surface-policy use case
+/// in neocortx where a fixed object is rendered from a moving camera many
+/// times per episode (issue #65).
+pub use render::PersistentRenderer;
 
 /// Create a new batch renderer helper for multi-viewpoint workflows.
 ///

--- a/src/render.rs
+++ b/src/render.rs
@@ -64,7 +64,7 @@ use bevy::window::{ExitCondition, WindowPlugin};
 use bevy_obj::ObjPlugin;
 use std::fs::File;
 use std::io::Read as IoRead;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -2752,6 +2752,311 @@ impl RenderSession {
             .zip(outputs)
             .map(|(req, out)| BatchRenderOutput::from_render_output(req, out))
             .collect())
+    }
+}
+
+// ============================================================================
+// Per-step persistent renderer (PersistentRenderer)
+//
+// `RenderSession` reuses the App across calls but rebuilds the scene on every
+// `render()` (despawn SceneRoot, re-issue asset_server.load, respawn). That's
+// fine for the parity-gate path (one scene per episode of N viewpoints) but
+// wasteful for surface-policy feedback loops where N=1 viewpoint per call and
+// the object stays loaded for the whole episode.
+//
+// `PersistentRenderer` commits to one `object_dir` + `RenderConfig` at
+// construction. `new()` loads mesh + texture + spawns the scene root + drives
+// one warmup render (output discarded) so PSO compilation and material setup
+// are paid up front. `render(camera, rotation)` then only mutates the camera
+// `Transform` and (if changed) the scene root rotation, drives the capture
+// chain for one frame, and returns. See issue #65.
+// ============================================================================
+
+/// Marker for the `PersistentRenderer`'s scene root entity. We keep the
+/// entity alive for the whole renderer lifetime and just mutate its
+/// `Transform` when the caller-supplied object rotation changes.
+#[derive(Component)]
+struct PersistentScene;
+
+/// Persistent per-step renderer. Loads the scene once at `new()` and renders
+/// one frame per `render()` call by mutating the camera transform and scene
+/// root rotation in-place. Built for surface-policy feedback loops where the
+/// object stays fixed for the duration of an episode and the camera moves
+/// every step. See issue #65.
+///
+/// # Thread affinity
+///
+/// `PersistentRenderer` must be created, used, and dropped on the same thread.
+/// Holds a `bevy::App` that owns GPU resources not safe to move across
+/// threads; `!Send + !Sync` is enforced via `PhantomData<*const ()>`.
+///
+/// # Object + config invariants
+///
+/// `object_dir` and `RenderConfig` are fixed at `new()`. To render a different
+/// object or change resolution/lighting, drop and rebuild. Rotation may change
+/// freely between `render()` calls.
+pub struct PersistentRenderer {
+    app: App,
+    object_dir: PathBuf,
+    render_config: RenderConfig,
+    shared_rgba: SharedRgbaBuffer,
+    shared_depth: SharedDepthBuffer,
+    _not_send_sync: std::marker::PhantomData<*const ()>,
+}
+
+impl PersistentRenderer {
+    /// Build the App, load the scene + texture, spawn the scene root, and drive
+    /// one warmup render whose output is discarded. After `new()` returns, the
+    /// first user-facing `render()` call benefits from a warm PSO cache and
+    /// applied materials.
+    pub fn new(
+        object_dir: &Path,
+        render_config: &RenderConfig,
+    ) -> Result<Self, crate::RenderError> {
+        let object_dir = std::fs::canonicalize(object_dir).map_err(|e| {
+            crate::RenderError::FileNotFound {
+                path: object_dir.display().to_string(),
+                reason: e.to_string(),
+            }
+        })?;
+        let mesh_path = object_dir.join(GOOGLE_16K_MESH_RELATIVE);
+        let texture_path = object_dir.join(GOOGLE_16K_TEXTURE_RELATIVE);
+        if !mesh_path.exists() {
+            return Err(crate::RenderError::MeshNotFound(
+                mesh_path.display().to_string(),
+            ));
+        }
+        if !texture_path.exists() {
+            return Err(crate::RenderError::TextureNotFound(
+                texture_path.display().to_string(),
+            ));
+        }
+
+        let shared_rgba: SharedRgbaBuffer = SharedRgbaBuffer::default();
+        let shared_depth: SharedDepthBuffer = SharedDepthBuffer::default();
+
+        let mut app = App::new();
+        app.add_plugins(
+            DefaultPlugins
+                .set(WindowPlugin {
+                    primary_window: None,
+                    exit_condition: ExitCondition::DontExit,
+                    ..default()
+                })
+                .disable::<bevy::winit::WinitPlugin>()
+                .disable::<LogPlugin>()
+                .disable::<TerminalCtrlCHandlerPlugin>(),
+        )
+        .add_plugins(ObjPlugin)
+        .add_plugins(ImageCopyPlugin {
+            shared_rgba: shared_rgba.clone(),
+        })
+        .add_plugins(DepthReadbackPlugin {
+            shared_depth: shared_depth.clone(),
+            near: render_config.near_plane,
+            far: render_config.far_plane,
+        })
+        .insert_resource(SessionRenderConfig(render_config.clone()))
+        .insert_resource(shared_rgba.clone())
+        .init_resource::<RenderState>()
+        .add_systems(Startup, setup_session_persistent_scene)
+        .add_systems(
+            Update,
+            (
+                check_assets_loaded,
+                apply_materials,
+                tick_headless_batch_warmup,
+                request_headless_capture,
+                check_headless_capture_ready,
+                extract_and_continue_headless_batch,
+            )
+                .chain()
+                // Same gate as RenderSession: capture chain only runs once
+                // RenderRequest is installed. Startup runs first via the
+                // warmup `app.update()` below.
+                .run_if(bevy::ecs::schedule::common_conditions::resource_exists::<RenderRequest>),
+        );
+
+        app.finish();
+        app.cleanup();
+        // Warmup tick #1: Startup runs (camera, lights, render target spawn).
+        app.update();
+
+        // Install scene + warmup render request. The warmup output is discarded
+        // — its purpose is to pay PSO compilation and material application
+        // upfront so the first user-facing render() is fast.
+        let initial_request = RenderRequest {
+            mesh_path: mesh_path.display().to_string(),
+            texture_path: texture_path.display().to_string(),
+            camera_transform: Transform::default(),
+            object_rotation: ObjectRotation::identity(),
+            config: render_config.clone(),
+        };
+
+        {
+            let world = app.world_mut();
+            let asset_server = world.resource::<AssetServer>().clone();
+            let scene_handle: Handle<Scene> =
+                asset_server.load(mesh_path.display().to_string());
+            let texture_handle: Handle<Image> =
+                asset_server.load(texture_path.display().to_string());
+            world.insert_resource(LoadedScene(scene_handle.clone()));
+            world.insert_resource(LoadedTexture(texture_handle));
+            world.insert_resource(initial_request);
+            world.spawn((
+                SceneRoot(scene_handle),
+                Transform::from_rotation(ObjectRotation::identity().to_quat()),
+                RenderedObject,
+                PersistentScene,
+            ));
+            world.insert_resource(HeadlessBatchSequence::new(vec![Transform::default()]));
+        }
+
+        // Drive the warmup render to completion.
+        let timeout = std::time::Duration::from_secs(RENDER_TIMEOUT_SECS);
+        let start = std::time::Instant::now();
+        loop {
+            if start.elapsed() > timeout {
+                return Err(crate::RenderError::RenderFailed(format!(
+                    "PersistentRenderer::new warmup render timed out after {RENDER_TIMEOUT_SECS}s"
+                )));
+            }
+            app.update();
+            if app.world().resource::<HeadlessBatchSequence>().done {
+                break;
+            }
+        }
+        // Discard the warmup output so it doesn't leak into the first real
+        // render() call's output buffer.
+        app.world_mut()
+            .resource_mut::<HeadlessBatchSequence>()
+            .outputs
+            .clear();
+
+        Ok(Self {
+            app,
+            object_dir,
+            render_config: render_config.clone(),
+            shared_rgba,
+            shared_depth,
+            _not_send_sync: std::marker::PhantomData,
+        })
+    }
+
+    /// Render one frame from the given camera transform and object rotation.
+    /// Reuses the loaded scene + warm PSO cache from `new()`.
+    pub fn render(
+        &mut self,
+        camera_transform: &Transform,
+        object_rotation: &ObjectRotation,
+    ) -> Result<RenderOutput, crate::RenderError> {
+        let camera_transform = *camera_transform;
+        let object_rotation_owned = object_rotation.clone();
+
+        {
+            let world = self.app.world_mut();
+
+            // Update the persistent scene root rotation. Always-write avoids
+            // the cost of an extra ObjectRotation comparison per call; the
+            // mutation itself is a single Transform write.
+            let scene_entity = world
+                .query_filtered::<Entity, With<PersistentScene>>()
+                .iter(world)
+                .next();
+            if let Some(entity) = scene_entity {
+                if let Some(mut transform) = world.entity_mut(entity).get_mut::<Transform>() {
+                    *transform = Transform::from_rotation(object_rotation_owned.to_quat());
+                }
+            }
+
+            // Update the camera transform.
+            let cam_entity = world
+                .query_filtered::<Entity, With<RenderCamera>>()
+                .iter(world)
+                .next();
+            if let Some(cam) = cam_entity {
+                if let Some(mut transform) = world.entity_mut(cam).get_mut::<Transform>() {
+                    *transform = camera_transform;
+                }
+            }
+
+            // Reset per-frame state, preserving scene_loaded / texture_loaded
+            // / materials_applied so apply_materials short-circuits and the
+            // capture chain runs immediately.
+            {
+                let mut state = world.resource_mut::<RenderState>();
+                state.exit_requested = false;
+                state.screenshot_requested = false;
+                state.captured = false;
+                state.rgba_data = None;
+                state.depth_data = None;
+                state.frame_count = 0;
+                state.image_width = 0;
+                state.image_height = 0;
+                state.capture_ready = true;
+            }
+
+            // Clear shared GPU readback buffers so a stale payload from the
+            // previous render() can't leak into this call's output.
+            if let Ok(mut guard) = self.shared_rgba.0.lock() {
+                *guard = None;
+            }
+            if let Ok(mut guard) = self.shared_depth.0.lock() {
+                *guard = None;
+            }
+
+            // Update RenderRequest (used by extract_and_continue_headless_batch
+            // to stamp the output with the right intrinsics + rotation).
+            {
+                let mut req = world.resource_mut::<RenderRequest>();
+                req.camera_transform = camera_transform;
+                req.object_rotation = object_rotation_owned.clone();
+            }
+
+            // Install fresh single-element batch.
+            world.insert_resource(HeadlessBatchSequence::new(vec![camera_transform]));
+        }
+
+        let timeout = std::time::Duration::from_secs(RENDER_TIMEOUT_SECS);
+        let start = std::time::Instant::now();
+        loop {
+            if start.elapsed() > timeout {
+                return Err(crate::RenderError::RenderFailed(format!(
+                    "PersistentRenderer::render timed out after {RENDER_TIMEOUT_SECS}s"
+                )));
+            }
+            self.app.update();
+            if self.app.world().resource::<HeadlessBatchSequence>().done {
+                break;
+            }
+        }
+
+        let mut sequence = self.app.world_mut().resource_mut::<HeadlessBatchSequence>();
+        let mut outputs = std::mem::take(&mut sequence.outputs);
+        if outputs.len() != 1 {
+            return Err(crate::RenderError::RenderFailed(format!(
+                "PersistentRenderer::render expected 1 output, got {}",
+                outputs.len()
+            )));
+        }
+
+        Ok(outputs.remove(0))
+    }
+
+    /// Path to the YCB object directory this renderer was bound to.
+    pub fn object_dir(&self) -> &Path {
+        &self.object_dir
+    }
+
+    /// The `RenderConfig` this renderer was constructed with.
+    pub fn render_config(&self) -> &RenderConfig {
+        &self.render_config
+    }
+
+    /// Explicit close. Equivalent to dropping; provided to match the API
+    /// proposal in #65 for callers that want lifetime-explicit teardown.
+    pub fn close(self) {
+        // Drop runs on return.
     }
 }
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -105,12 +105,14 @@ const BATCH_WARMUP_FRAMES: u32 = 1;
 /// `transform_propagate` → `Extract` → render graph → `ImageCopyDriver`
 /// before the capture we request actually reflects the new transforms.
 ///
-/// Validated by `test_persistent_renderer_matches_render_to_buffer`. Two
-/// ticks of warmup gives:
+/// Validated by `test_persistent_renderer_matches_render_to_buffer`. Three
+/// ticks of warmup gives Windows/DX12 enough room to drain the previous
+/// readback and capture the post-propagation color target:
 ///   - tick 0: transforms propagate, render runs (no copy enabled)
-///   - tick 1: warmup hits 0, capture fires, render runs with copy enabled
-///   - tick 2: shared buffers populated → captured → batch finalized
-const PERSISTENT_WARMUP_FRAMES: u32 = 2;
+///   - tick 1: previous in-flight readback drains (no copy enabled)
+///   - tick 2: warmup hits 0, capture fires, render runs with copy enabled
+///   - tick 3: shared buffers populated → captured → batch finalized
+const PERSISTENT_WARMUP_FRAMES: u32 = 3;
 
 /// Check the render-trace env var. Cheap enough (single HashMap lookup) to call
 /// from per-frame systems; gate all tracing output behind this.

--- a/src/render.rs
+++ b/src/render.rs
@@ -90,6 +90,28 @@ const RENDER_TIMEOUT_SECS: u64 = 180;
 /// `test_batch_render_matches_sequential_episode_outputs`.
 const BATCH_WARMUP_FRAMES: u32 = 1;
 
+/// Warmup frames at the start of each `PersistentRenderer::render()` call.
+///
+/// `BATCH_WARMUP_FRAMES = 1` works for inter-viewpoint advancement inside a
+/// batch because `extract_and_continue_headless_batch` writes the next
+/// camera transform *and* clears the shared GPU readback buffers in the
+/// same tick — so the in-flight copy from the previous viewpoint has
+/// already drained by the time the next capture is gated.
+///
+/// In the persistent per-call path, the previous render's output may still
+/// be sitting in `shared_rgba`/`shared_depth` (we clear them before the
+/// loop, but the pipeline still needs ticks to propagate the new camera/
+/// scene-rotation `Transform` writes through `PostUpdate` →
+/// `transform_propagate` → `Extract` → render graph → `ImageCopyDriver`
+/// before the capture we request actually reflects the new transforms.
+///
+/// Validated by `test_persistent_renderer_matches_render_to_buffer`. Two
+/// ticks of warmup gives:
+///   - tick 0: transforms propagate, render runs (no copy enabled)
+///   - tick 1: warmup hits 0, capture fires, render runs with copy enabled
+///   - tick 2: shared buffers populated → captured → batch finalized
+const PERSISTENT_WARMUP_FRAMES: u32 = 2;
+
 /// Check the render-trace env var. Cheap enough (single HashMap lookup) to call
 /// from per-frame systems; gate all tracing output behind this.
 #[inline]
@@ -2813,12 +2835,11 @@ impl PersistentRenderer {
         object_dir: &Path,
         render_config: &RenderConfig,
     ) -> Result<Self, crate::RenderError> {
-        let object_dir = std::fs::canonicalize(object_dir).map_err(|e| {
-            crate::RenderError::FileNotFound {
+        let object_dir =
+            std::fs::canonicalize(object_dir).map_err(|e| crate::RenderError::FileNotFound {
                 path: object_dir.display().to_string(),
                 reason: e.to_string(),
-            }
-        })?;
+            })?;
         let mesh_path = object_dir.join(GOOGLE_16K_MESH_RELATIVE);
         let texture_path = object_dir.join(GOOGLE_16K_TEXTURE_RELATIVE);
         if !mesh_path.exists() {
@@ -2896,8 +2917,7 @@ impl PersistentRenderer {
         {
             let world = app.world_mut();
             let asset_server = world.resource::<AssetServer>().clone();
-            let scene_handle: Handle<Scene> =
-                asset_server.load(mesh_path.display().to_string());
+            let scene_handle: Handle<Scene> = asset_server.load(mesh_path.display().to_string());
             let texture_handle: Handle<Image> =
                 asset_server.load(texture_path.display().to_string());
             world.insert_resource(LoadedScene(scene_handle.clone()));
@@ -2981,8 +3001,19 @@ impl PersistentRenderer {
             }
 
             // Reset per-frame state, preserving scene_loaded / texture_loaded
-            // / materials_applied so apply_materials short-circuits and the
-            // capture chain runs immediately.
+            // / materials_applied / materials_applied_frame. The asset-load
+            // and material-apply work was paid in `new()`'s warmup; we only
+            // need to clear the per-capture state.
+            //
+            // `capture_ready = true` short-circuits `apply_materials` on
+            // every tick of the render loop (no need to re-check material
+            // application — it stays applied for the renderer's lifetime).
+            // It does NOT short-circuit `request_headless_capture`, which
+            // is gated by `HeadlessBatchSequence::warmup_frames_remaining`
+            // below. Bug fix from PR #66 review (off-by-one / blank-step-0):
+            // without that warmup gate, request_headless_capture fires same-
+            // tick as the transform writes, capturing the previous render's
+            // target before the new transforms have propagated.
             {
                 let mut state = world.resource_mut::<RenderState>();
                 state.exit_requested = false;
@@ -3013,8 +3044,12 @@ impl PersistentRenderer {
                 req.object_rotation = object_rotation_owned.clone();
             }
 
-            // Install fresh single-element batch.
-            world.insert_resource(HeadlessBatchSequence::new(vec![camera_transform]));
+            // Install fresh single-element batch with warmup frames so
+            // `request_headless_capture` is gated until the new transforms
+            // have propagated through the render pipeline.
+            let mut batch = HeadlessBatchSequence::new(vec![camera_transform]);
+            batch.warmup_frames_remaining = PERSISTENT_WARMUP_FRAMES;
+            world.insert_resource(batch);
         }
 
         let timeout = std::time::Duration::from_secs(RENDER_TIMEOUT_SECS);

--- a/tests/render_integration.rs
+++ b/tests/render_integration.rs
@@ -847,8 +847,7 @@ fn test_persistent_renderer_matches_render_to_buffer() {
         .collect();
 
     // Persistent path: single renderer, N calls.
-    let mut renderer =
-        PersistentRenderer::new(&object_dir, &config).expect("renderer init failed");
+    let mut renderer = PersistentRenderer::new(&object_dir, &config).expect("renderer init failed");
     let persistent: Vec<RenderOutput> = sequence
         .iter()
         .map(|(rot, vp)| renderer.render(vp, rot).expect("persistent render failed"))
@@ -912,7 +911,9 @@ fn test_persistent_renderer_per_step_throughput_smoke() {
     let t1 = Instant::now();
     for i in 0..STEPS {
         let vp = &viewpoints[i % viewpoints.len()];
-        let _ = renderer.render(vp, &rotation).expect("persistent render failed");
+        let _ = renderer
+            .render(vp, &rotation)
+            .expect("persistent render failed");
     }
     let persistent_steps = t1.elapsed();
 
@@ -932,8 +933,7 @@ fn test_persistent_renderer_per_step_throughput_smoke() {
     }
     let per_step_session = t2.elapsed();
 
-    let persistent_per_step_ms =
-        persistent_steps.as_secs_f64() * 1000.0 / STEPS as f64;
+    let persistent_per_step_ms = persistent_steps.as_secs_f64() * 1000.0 / STEPS as f64;
     let session_per_step_ms = per_step_session.as_secs_f64() * 1000.0 / STEPS as f64;
 
     println!(

--- a/tests/render_integration.rs
+++ b/tests/render_integration.rs
@@ -18,8 +18,8 @@
 
 use bevy_sensor::{
     backend::detect_platform, batch::BatchRenderRequest, cache::ModelCache, render_batch,
-    render_to_buffer, render_to_buffer_cached, BatchRenderConfig, ObjectRotation, RenderConfig,
-    RenderOutput, RenderSession, ViewpointConfig,
+    render_to_buffer, render_to_buffer_cached, BatchRenderConfig, ObjectRotation,
+    PersistentRenderer, RenderConfig, RenderOutput, RenderSession, ViewpointConfig,
 };
 use std::fs;
 use std::path::PathBuf;
@@ -788,4 +788,176 @@ fn test_cache_with_multiple_viewpoints() {
         render_count
     );
     println!("✓ Multiple viewpoints cache test passed");
+}
+
+/// Pixel-exact correctness gate for `PersistentRenderer` (issue #65) against
+/// the authoritative per-call `render_to_buffer()` path.
+///
+/// Validates that the in-place camera + scene-rotation mutation in
+/// `PersistentRenderer::render()` produces identical output to a freshly-built
+/// app per call, across:
+///   - multiple viewpoints (camera moves between calls — the surface-policy
+///     case)
+///   - multiple rotations (object rotation changes between calls)
+///   - both interleaved (rotation flips, then camera moves, then rotation
+///     flips again — catches state bleed in the rotation-mutation path)
+///
+/// Failure modes this catches:
+///   - SceneRoot Transform not updated → wrong rotation in the output.
+///   - Per-frame state reset misses a field → stale RGBA/depth from prior
+///     render leaks into output.
+///   - shared_rgba/depth buffer not cleared → next frame returns previous
+///     payload before new capture completes.
+///
+/// Requires native GPU. Skipped if YCB models aren't present.
+#[test]
+#[ignore]
+fn test_persistent_renderer_matches_render_to_buffer() {
+    println!("\n=== PersistentRenderer vs render_to_buffer pixel-exact gate ===");
+
+    let object_dir = PathBuf::from("/tmp/ycb/003_cracker_box");
+    if !object_dir.exists() {
+        println!("⚠ Skipping - YCB models not found at {:?}", object_dir);
+        return;
+    }
+
+    let viewpoint_config = ViewpointConfig::default();
+    let viewpoints = bevy_sensor::generate_viewpoints(&viewpoint_config);
+    let rotations = ObjectRotation::tbp_benchmark_rotations();
+    let config = RenderConfig::tbp_default();
+
+    // Build an interleaved sequence: alternate rotations across viewpoints to
+    // exercise the per-call rotation-mutation path, not just the camera-only
+    // path. 6 calls is enough to catch state bleed without making the test
+    // brutally slow.
+    let sequence: Vec<(ObjectRotation, &bevy::prelude::Transform)> = (0..6)
+        .map(|i| {
+            let rot = rotations[i % rotations.len()].clone();
+            let vp = &viewpoints[i % viewpoints.len()];
+            (rot, vp)
+        })
+        .collect();
+
+    // Reference: fresh render_to_buffer per call.
+    let reference: Vec<RenderOutput> = sequence
+        .iter()
+        .map(|(rot, vp)| {
+            render_to_buffer(&object_dir, vp, rot, &config).expect("reference render failed")
+        })
+        .collect();
+
+    // Persistent path: single renderer, N calls.
+    let mut renderer =
+        PersistentRenderer::new(&object_dir, &config).expect("renderer init failed");
+    let persistent: Vec<RenderOutput> = sequence
+        .iter()
+        .map(|(rot, vp)| renderer.render(vp, rot).expect("persistent render failed"))
+        .collect();
+
+    for (idx, (r, p)) in reference.iter().zip(persistent.iter()).enumerate() {
+        assert_eq!(p.width, r.width, "step {idx}: width");
+        assert_eq!(p.height, r.height, "step {idx}: height");
+        assert_eq!(p.intrinsics, r.intrinsics, "step {idx}: intrinsics");
+        assert_eq!(
+            p.rgba, r.rgba,
+            "step {idx}: RGBA differs between PersistentRenderer and render_to_buffer"
+        );
+        assert_eq!(p.depth.len(), r.depth.len(), "step {idx}: depth length");
+        let max_delta = p
+            .depth
+            .iter()
+            .zip(r.depth.iter())
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0_f64, f64::max);
+        assert!(
+            max_delta <= 1e-9,
+            "step {idx}: depth max delta {max_delta} exceeds 1e-9"
+        );
+        println!("  ✓ step {idx} pixel-exact");
+    }
+
+    println!("✓ PersistentRenderer pixel-exact gate PASSED");
+}
+
+/// Throughput smoke gate: `PersistentRenderer` should be at least as fast as
+/// constructing a fresh `RenderSession` per single-viewpoint call. Real
+/// speedup numbers come from the `examples/persistent_per_step.rs` bench;
+/// this test just guards the correctness assumption that the per-call
+/// scene-mutation path doesn't regress wall-clock vs. per-call session
+/// rebuild.
+///
+/// Requires native GPU.
+#[test]
+#[ignore]
+fn test_persistent_renderer_per_step_throughput_smoke() {
+    println!("\n=== PersistentRenderer per-step throughput smoke ===");
+
+    let object_dir = PathBuf::from("/tmp/ycb/003_cracker_box");
+    if !object_dir.exists() {
+        println!("⚠ Skipping - YCB models not found");
+        return;
+    }
+
+    let viewpoint_config = ViewpointConfig::default();
+    let viewpoints = bevy_sensor::generate_viewpoints(&viewpoint_config);
+    let config = RenderConfig::tbp_default();
+    let rotation = ObjectRotation::identity();
+    const STEPS: usize = 20;
+
+    // PersistentRenderer: one renderer, STEPS render() calls.
+    let t0 = Instant::now();
+    let mut renderer =
+        PersistentRenderer::new(&object_dir, &config).expect("persistent init failed");
+    let persistent_init = t0.elapsed();
+    let t1 = Instant::now();
+    for i in 0..STEPS {
+        let vp = &viewpoints[i % viewpoints.len()];
+        let _ = renderer.render(vp, &rotation).expect("persistent render failed");
+    }
+    let persistent_steps = t1.elapsed();
+
+    // Per-step RenderSession: fresh session per call (matches the ergonomic
+    // shape neocortx would use today without PersistentRenderer).
+    let t2 = Instant::now();
+    for i in 0..STEPS {
+        let vp = &viewpoints[i % viewpoints.len()];
+        let mut session = RenderSession::new(&config).expect("session init failed");
+        let req = BatchRenderRequest {
+            object_dir: object_dir.clone(),
+            viewpoint: *vp,
+            object_rotation: rotation.clone(),
+            render_config: config.clone(),
+        };
+        let _ = session.render(&[req]).expect("session render failed");
+    }
+    let per_step_session = t2.elapsed();
+
+    let persistent_per_step_ms =
+        persistent_steps.as_secs_f64() * 1000.0 / STEPS as f64;
+    let session_per_step_ms = per_step_session.as_secs_f64() * 1000.0 / STEPS as f64;
+
+    println!(
+        "  PersistentRenderer: init {:.0} ms, {} steps in {:.0} ms ({:.1} ms/step)",
+        persistent_init.as_secs_f64() * 1000.0,
+        STEPS,
+        persistent_steps.as_secs_f64() * 1000.0,
+        persistent_per_step_ms,
+    );
+    println!(
+        "  Fresh RenderSession per call: {} steps in {:.0} ms ({:.1} ms/step)",
+        STEPS,
+        per_step_session.as_secs_f64() * 1000.0,
+        session_per_step_ms,
+    );
+    let speedup = session_per_step_ms / persistent_per_step_ms;
+    println!("  Speedup vs fresh session per call: {:.2}x", speedup);
+
+    assert!(
+        persistent_per_step_ms <= session_per_step_ms,
+        "PersistentRenderer per-step ({:.1} ms) should be <= fresh-session-per-call ({:.1} ms)",
+        persistent_per_step_ms,
+        session_per_step_ms,
+    );
+
+    println!("✓ Throughput smoke PASSED");
 }


### PR DESCRIPTION
Closes #65.

## Summary

Adds `PersistentRenderer` — a renderer committed to a single `object_dir` + `RenderConfig` at construction. `render(camera, rotation)` mutates the camera transform and scene-root rotation in place and drives one capture, reusing the loaded scene and warm PSO cache.

Built for the surface-policy feedback loop in neocortx (TBP `SurfacePolicy` port — neocortx#204, #206, #207): one render per motor step, same object the whole episode. `RenderSession` (PR #59) amortizes the App but still respawns the scene every `render()` call; this path keeps the scene loaded and only mutates the camera + scene root.

## API (matches issue #65 proposal)

```rust
use bevy_sensor::{PersistentRenderer, RenderConfig, ObjectRotation};

let mut renderer = PersistentRenderer::new(&object_dir, &RenderConfig::tbp_default())?;
loop {
    let output = renderer.render(&camera_transform, &object_rotation)?;
    // feed depth + RGBA back into the policy, get next motor action ...
}
renderer.close();
```

### Invariants

- **Thread affinity**: `!Send + !Sync` via `PhantomData<*const ()>` (same as `RenderSession`).
- **Object + config fixed at `new()`**: change object or resolution/lighting → drop and rebuild. Rotation may change between `render()` calls.
- **Warmup amortization**: `new()` drives one render whose output is discarded so PSO compilation and material application are paid up front; subsequent `render()` calls hit the warm cache.

## What's in

- `src/render.rs` — `PersistentRenderer` + `PersistentScene` marker; reuses `setup_session_persistent_scene`, the existing capture chain, and the `HeadlessBatchSequence` plumbing (single-element batch per call).
- `src/lib.rs` — re-export. Also rewrites the `render_to_buffer_cached` docstring at L811 that predated both `RenderSession` and this PR (claimed there was no persistent renderer).
- `tests/render_integration.rs` (`#[ignore]`, GPU-required):
  - `test_persistent_renderer_matches_render_to_buffer` — pixel-exact RGBA + depth-epsilon-1e-9 across 6 interleaved (rotation, viewpoint) steps. Catches stale-buffer leakage and rotation-mutation bugs.
  - `test_persistent_renderer_per_step_throughput_smoke` — asserts persistent per-step ≤ fresh-session-per-call.
- `examples/persistent_per_step.rs` — 3-way bench (`render_to_buffer` per call, fresh `RenderSession` per call, `PersistentRenderer`) producing the speedup number #65 asked for. Run: `cargo run --example persistent_per_step --release`.

## What's out (follow-ups, not blockers)

- Multi-object renderer pool — out of scope; one `PersistentRenderer` per object is the natural shape.
- `render_batch` / `RenderSession` refactor on top of `PersistentRenderer` — cleanup, not a feature.

## Test plan

- [x] `cargo build --release --all-targets` clean.
- [x] `cargo test --lib --release` — 83/83 pass (lib).
- [ ] **GPU gate (asking neocortx team to run)**: `cargo test --release --test render_integration -- --ignored test_persistent_renderer_ --nocapture`.
- [ ] **Bench (asking neocortx team to run)**: `cargo run --example persistent_per_step --release -- --steps 100`.

Once the pixel-exact gate passes on neocortx-side hardware, this is good to land. The neocortx surface-policy port (#204) can then move from per-call `render_to_buffer` to `PersistentRenderer::render` for the feedback loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)