### PR TITLE
fix(release): keep 0.x features as minor bumps

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,3 +1,8 @@
 [workspace]
 # Allow dirty working directory (assets/ycb symlink is gitignored but present locally)
 allow_dirty = true
+
+# This crate is still 0.x, but downstream users treat the minor slot as the
+# compatibility boundary. Keep release-plz from flattening `feat` / `feat!`
+# commits into patch bumps while pre-1.0.
+features_always_increment_minor = true


### PR DESCRIPTION
Closes #64.

## Summary

- Sets `features_always_increment_minor = true` in `release-plz.toml`.
- Documents the project convention that, while bevy-sensor is still 0.x, the minor slot is the downstream compatibility boundary.
- Prevents future `feat` / `feat!` releases from being flattened into patch bumps by release-plz during pre-1.0 development.

## Test plan

- `cargo test --release --all-targets`