### PR TITLE
fix(render): align output intrinsics with TBP zoom formula

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,7 +413,7 @@ pub struct RenderConfig {
     pub width: u32,
     /// Image height in pixels (default: 64)
     pub height: u32,
-    /// Zoom factor affecting field of view (default: 1.0)
+    /// Zoom factor affecting field of view (`tbp_default`: 4.0)
     /// Use >1 to zoom in (narrower FOV), <1 to zoom out (wider FOV)
     pub zoom: f32,
     /// Near clipping plane in meters (default: 0.01)
@@ -503,11 +503,11 @@ impl Default for RenderConfig {
 impl RenderConfig {
     /// TBP-compatible 64x64 RGBD patch sensor configuration.
     ///
-    /// Matches TBP's habitat distant patch sensor: 64x64 resolution with
-    /// zoom=10 (90° base HFOV → ~9° effective FOV), producing a tight view
-    /// of the object's surface patch.
+    /// Uses TBP's 90° base-HFOV zoom formula with a 64x64 patch render. TBP's
+    /// Habitat patch sensor uses zoom=10 with a separate viewfinder; the current
+    /// single-sensor YCB benchmark keeps zoom=4 for centering stability.
     ///
-    /// TBP ref: `missing_depthto3d_sensor2_semantic0.yaml` (zoom=10)
+    /// TBP ref: `missing_depthto3d_sensor2_semantic0.yaml` (zoom=10 upstream)
     pub fn tbp_default() -> Self {
         Self {
             width: 64,
@@ -563,17 +563,25 @@ impl RenderConfig {
     ///
     /// TBP ref: `transforms.py:440` `fx = np.tan(hfov[i] / 2.0) / zoom`
     pub fn intrinsics(&self) -> CameraIntrinsics {
+        self.intrinsics_for_size(self.width, self.height)
+    }
+
+    /// Compute camera intrinsics for a concrete render target size.
+    ///
+    /// This keeps readback metadata aligned with the actual image dimensions
+    /// while preserving TBP's focal-length-space zoom formula.
+    pub fn intrinsics_for_size(&self, width: u32, height: u32) -> CameraIntrinsics {
         let base_hfov_rad = 90.0_f64.to_radians();
         // TBP normalized focal length: fx_norm = tan(hfov/2) / zoom
         let fx_norm = (base_hfov_rad / 2.0).tan() / self.zoom as f64;
         // Convert to pixel focal length: fx_pixel = (width/2) / fx_norm
-        let fx = (self.width as f64 / 2.0) / fx_norm;
+        let fx = (width as f64 / 2.0) / fx_norm;
         let fy = fx; // Square pixels (TBP adjusts fy for aspect ratio, but we use 64x64)
 
         CameraIntrinsics {
             focal_length: [fx, fy],
-            principal_point: [self.width as f64 / 2.0, self.height as f64 / 2.0],
-            image_size: [self.width, self.height],
+            principal_point: [width as f64 / 2.0, height as f64 / 2.0],
+            image_size: [width, height],
         }
     }
 }
@@ -1391,6 +1399,43 @@ mod tests {
         // Square pixels: fx == fy.
         assert_eq!(intrinsics.focal_length[0], intrinsics.focal_length[1]);
         assert!(intrinsics.focal_length[0] > 0.0);
+    }
+
+    #[test]
+    fn test_render_config_intrinsics_for_size_uses_tbp_zoom_formula() {
+        let config = RenderConfig {
+            width: 64,
+            height: 64,
+            zoom: 4.0,
+            ..RenderConfig::tbp_default()
+        };
+
+        let intrinsics = config.intrinsics_for_size(64, 64);
+
+        // TBP formula for 90° base HFOV:
+        // fx = (width / 2) / (tan(45°) / zoom) = (width / 2) * zoom.
+        assert!((intrinsics.focal_length[0] - 128.0).abs() < 1e-9);
+        assert!((intrinsics.focal_length[1] - 128.0).abs() < 1e-9);
+        assert_ne!(intrinsics.focal_length[0], 64.0 * config.zoom as f64);
+        assert_eq!(intrinsics.principal_point, [32.0, 32.0]);
+        assert_eq!(intrinsics.image_size, [64, 64]);
+    }
+
+    #[test]
+    fn test_render_config_intrinsics_for_size_tracks_actual_readback_size() {
+        let config = RenderConfig {
+            width: 64,
+            height: 64,
+            zoom: 4.0,
+            ..RenderConfig::tbp_default()
+        };
+
+        let intrinsics = config.intrinsics_for_size(128, 96);
+
+        assert!((intrinsics.focal_length[0] - 256.0).abs() < 1e-9);
+        assert!((intrinsics.focal_length[1] - 256.0).abs() < 1e-9);
+        assert_eq!(intrinsics.principal_point, [64.0, 48.0]);
+        assert_eq!(intrinsics.image_size, [128, 96]);
     }
 
     #[test]

--- a/src/render.rs
+++ b/src/render.rs
@@ -1885,16 +1885,8 @@ fn extract_and_exit(
         let width = state.image_width;
         let height = state.image_height;
 
-        // Compute intrinsics based on actual dimensions (f64 for TBP precision)
-        let config = &request.config;
-        let intrinsics = crate::CameraIntrinsics {
-            focal_length: [
-                width as f64 * config.zoom as f64,
-                height as f64 * config.zoom as f64,
-            ],
-            principal_point: [width as f64 / 2.0, height as f64 / 2.0],
-            image_size: [width, height],
-        };
+        // Compute intrinsics from the same TBP zoom formula as the camera projection.
+        let intrinsics = request.config.intrinsics_for_size(width, height);
 
         let output = RenderOutput {
             rgba: rgba.clone(),
@@ -2220,16 +2212,8 @@ fn extract_and_exit_headless(
         let width = state.image_width;
         let height = state.image_height;
 
-        // Compute intrinsics (f64 for TBP precision)
-        let config = &request.config;
-        let intrinsics = crate::CameraIntrinsics {
-            focal_length: [
-                width as f64 * config.zoom as f64,
-                height as f64 * config.zoom as f64,
-            ],
-            principal_point: [width as f64 / 2.0, height as f64 / 2.0],
-            image_size: [width, height],
-        };
+        // Compute intrinsics from the same TBP zoom formula as the camera projection.
+        let intrinsics = request.config.intrinsics_for_size(width, height);
 
         let output = RenderOutput {
             rgba: rgba.clone(),
@@ -2304,15 +2288,7 @@ fn extract_and_continue_headless_batch(
         let width = state.image_width;
         let height = state.image_height;
 
-        let config = &request.config;
-        let intrinsics = crate::CameraIntrinsics {
-            focal_length: [
-                width as f64 * config.zoom as f64,
-                height as f64 * config.zoom as f64,
-            ],
-            principal_point: [width as f64 / 2.0, height as f64 / 2.0],
-            image_size: [width, height],
-        };
+        let intrinsics = request.config.intrinsics_for_size(width, height);
 
         let output = RenderOutput {
             rgba: rgba.clone(),


### PR DESCRIPTION
## Summary
- add `RenderConfig::intrinsics_for_size` so render-output metadata uses the same TBP zoom formula as `RenderConfig::intrinsics`
- replace the three render readback paths that hand-built `CameraIntrinsics` as `width * zoom` / `height * zoom`
- add tests covering the 64x64 zoom=4 TBP formula and actual readback-size metadata

NeoCortx parity context: this is a child-repo slice for killerapp/neocortx#188. It fixes the metadata/projection mismatch without changing the current single-sensor default zoom.

## Validation
- `cargo test intrinsics`
- `cargo test --lib --tests --bins`
- `cargo check --lib --bins --tests`
- `cargo fmt --all -- --check`
- `git diff --check`

Note: full `cargo test` was attempted, but this local machine hit `fatal error LNK1180: insufficient disk space to complete link` while linking examples, followed by PDB errors. The no-example library/bin/test suite passed after cleaning generated target output.