### PR TITLE
Fix YCB validation, render intrinsics, and Windows build coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,19 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
 
+  windows-check:
+    runs-on: windows-latest
+    env:
+      CARGO_BUILD_JOBS: "1"
+      CARGO_INCREMENTAL: "0"
+      RUSTFLAGS: "-Cdebuginfo=0"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Check all targets
+        run: cargo check --locked --all-targets
+
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This crate is intentionally narrow in scope: it exists to support TBP-compatible
 
 ## Requirements
 
-- **Rust:** 1.70+
+- **Rust:** 1.82+ (Bevy 0.15 MSRV)
 - **Bevy:** 0.15+
 - **System:** Linux with Vulkan drivers (or WSL2).
 - **Tools:** `just` (recommended command runner).
@@ -33,6 +33,14 @@ This crate is intentionally narrow in scope: it exists to support TBP-compatible
     # Models will be automatically downloaded to /tmp/ycb if missing.
     # To use a custom location: cargo run --bin prerender -- --data-dir ./my_models ...
     # Output saved to test_fixtures/renders/
+    ```
+
+    On memory-constrained Windows machines, build once before running large
+    benchmarks and limit Cargo parallelism:
+    ```powershell
+    $env:CARGO_BUILD_JOBS = "1"
+    cargo build --bin prerender
+    just render-tbp-benchmark
     ```
 
 ## Usage

--- a/src/bin/prerender.rs
+++ b/src/bin/prerender.rs
@@ -18,7 +18,7 @@ use bevy_sensor::{generate_viewpoints, ObjectRotation, RenderConfig, ViewpointCo
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// Metadata for a pre-rendered dataset
@@ -116,21 +116,7 @@ fn run_single_render_impl(args: &[String]) -> Result<(), Box<dyn std::error::Err
 
     let ycb_dir = PathBuf::from(&data_dir_str);
 
-    // Check if YCB models exist
-    if !ycb::models_exist(&ycb_dir) {
-        println!("\nYCB models not found at {:?}", ycb_dir);
-        println!("Downloading representative models...");
-
-        if let Err(e) = ycbust::blocking::download_ycb_blocking(
-            ycb::Subset::Representative,
-            &ycb_dir,
-            ycbust::DownloadOptions::default(),
-        ) {
-            eprintln!("Failed to download models: {}", e);
-            std::process::exit(1);
-        }
-        println!("Download complete.");
-    }
+    ensure_ycb_objects(&ycb_dir, &[object_id.as_str()])?;
 
     // Canonicalize to ensure absolute path for Bevy asset loading
     let ycb_dir = fs::canonicalize(&ycb_dir).unwrap_or(ycb_dir);
@@ -199,22 +185,9 @@ fn run_batch_render_impl(args: &[String]) -> Result<(), Box<dyn std::error::Erro
     println!("Data directory: {}", data_dir_str);
     println!("Objects: {:?}", objects);
 
-    // Check if YCB models exist
     let ycb_dir = PathBuf::from(&data_dir_str);
-    if !ycb::models_exist(&ycb_dir) {
-        println!("\nYCB models not found at {:?}", ycb_dir);
-        println!("Downloading representative models...");
-
-        if let Err(e) = ycbust::blocking::download_ycb_blocking(
-            ycb::Subset::Representative,
-            &ycb_dir,
-            ycbust::DownloadOptions::default(),
-        ) {
-            eprintln!("Failed to download models: {}", e);
-            std::process::exit(1);
-        }
-        println!("Download complete.");
-    }
+    let object_refs: Vec<&str> = objects.iter().map(String::as_str).collect();
+    ensure_ycb_objects(&ycb_dir, &object_refs)?;
 
     // Canonicalize to ensure absolute path for Bevy asset loading
     let ycb_dir = fs::canonicalize(&ycb_dir).unwrap_or(ycb_dir);
@@ -413,4 +386,36 @@ fn parse_arg(args: &[String], flag: &str) -> Option<String> {
     args.iter()
         .position(|a| a == flag)
         .and_then(|i| args.get(i + 1).cloned())
+}
+
+fn ensure_ycb_objects(
+    ycb_dir: &Path,
+    object_ids: &[&str],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let missing = ycb::missing_objects(ycb_dir, object_ids);
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    println!("\nMissing YCB objects at {:?}: {:?}", ycb_dir, missing);
+    println!("Downloading missing objects...");
+
+    let missing_refs: Vec<&str> = missing.iter().map(String::as_str).collect();
+    ycbust::blocking::download_objects_blocking(
+        &missing_refs,
+        ycb_dir,
+        ycbust::DownloadOptions::default(),
+    )?;
+
+    let still_missing = ycb::missing_objects(ycb_dir, object_ids);
+    if !still_missing.is_empty() {
+        return Err(format!(
+            "YCB download completed but objects are still incomplete: {:?}",
+            still_missing
+        )
+        .into());
+    }
+
+    println!("Download complete.");
+    Ok(())
 }

--- a/src/bin/prerender.rs
+++ b/src/bin/prerender.rs
@@ -9,17 +9,19 @@
 //! Default output: test_fixtures/renders/
 //! Default objects: 003_cracker_box, 005_tomato_soup_can
 //!
-//! For single-render mode (used internally for subprocess rendering):
+//! For single-render mode:
 //!   cargo run --bin prerender -- --single-render --object <name> --rotation <idx> --viewpoint <idx> --output <dir>
 
 use bevy_sensor::ycb;
 use bevy_sensor::ycbust;
-use bevy_sensor::{generate_viewpoints, ObjectRotation, RenderConfig, ViewpointConfig};
+use bevy_sensor::{
+    generate_viewpoints, render_batch, BatchRenderConfig, BatchRenderOutput, BatchRenderRequest,
+    ObjectRotation, RenderConfig, RenderStatus, ViewpointConfig,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 /// Metadata for a pre-rendered dataset
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -81,7 +83,7 @@ fn main() {
     // Parse command line arguments
     let args: Vec<String> = std::env::args().collect();
 
-    // Check for single-render mode (used by batch subprocess)
+    // Keep single-render mode available for scripts that render one capture.
     if args.iter().any(|a| a == "--single-render") {
         run_single_render(&args);
         return;
@@ -267,11 +269,8 @@ fn run_batch_render_impl(args: &[String]) -> Result<(), Box<dyn std::error::Erro
     })?;
     println!("\nSaved dataset metadata to {:?}", metadata_path);
 
-    // Get the current executable path for subprocess spawning
-    let exe_path = std::env::current_exe()
-        .map_err(|e| format!("Failed to get current executable path: {}", e))?;
-
-    // Render each object using subprocesses
+    // Render each object in-process. Grouping by object and rotation lets the library reuse
+    // scene setup across the 24 viewpoints while keeping output filenames unchanged.
     let mut all_render_metadata: HashMap<String, Vec<RenderMetadata>> = HashMap::new();
 
     for object_id in &objects {
@@ -279,9 +278,11 @@ fn run_batch_render_impl(args: &[String]) -> Result<(), Box<dyn std::error::Erro
 
         let object_dir = ycb_dir.join(object_id);
         if !object_dir.exists() {
-            println!("  WARNING: Object directory not found: {:?}", object_dir);
-            println!("  Skipping...");
-            continue;
+            return Err(format!(
+                "Object directory not found after validation: {:?}",
+                object_dir
+            )
+            .into());
         }
 
         // Create object output directory
@@ -299,59 +300,57 @@ fn run_batch_render_impl(args: &[String]) -> Result<(), Box<dyn std::error::Erro
         let total_renders = viewpoints.len() * rotations.len();
 
         for (rot_idx, rotation) in rotations.iter().enumerate() {
-            for (view_idx, viewpoint) in viewpoints.iter().enumerate() {
-                // Spawn subprocess to render this viewpoint
-                let status = Command::new(&exe_path)
-                    .arg("--single-render")
-                    .arg("--object")
-                    .arg(object_id)
-                    .arg("--rotation")
-                    .arg(rot_idx.to_string())
-                    .arg("--viewpoint")
-                    .arg(view_idx.to_string())
-                    .arg("--output")
-                    .arg(&output_dir)
-                    .arg("--data-dir")
-                    .arg(&data_dir_str)
-                    .status();
+            let requests: Vec<BatchRenderRequest> = viewpoints
+                .iter()
+                .map(|viewpoint| BatchRenderRequest {
+                    object_dir: object_dir.clone(),
+                    viewpoint: *viewpoint,
+                    object_rotation: rotation.clone(),
+                    render_config: render_config.clone(),
+                })
+                .collect();
 
-                match status {
-                    Ok(exit_status) if exit_status.success() => {
-                        // Record metadata
-                        let camera_pos = viewpoint.translation;
-                        object_renders.push(RenderMetadata {
-                            object_id: object_id.clone(),
-                            rotation_index: rot_idx,
-                            viewpoint_index: view_idx,
-                            // Convert f64 rotation to f32 for JSON serialization
-                            rotation_euler: [
-                                rotation.pitch as f32,
-                                rotation.yaw as f32,
-                                rotation.roll as f32,
-                            ],
-                            camera_position: [camera_pos.x, camera_pos.y, camera_pos.z],
-                            rgba_file: format!("r{}_v{:02}.png", rot_idx, view_idx),
-                            depth_file: format!("r{}_v{:02}.depth", rot_idx, view_idx),
-                        });
+            let outputs = render_batch(requests, &BatchRenderConfig::default()).map_err(|e| {
+                format!("Failed to render {} rotation {}: {}", object_id, rot_idx, e)
+            })?;
 
-                        render_count += 1;
-                        print!("\r  Rendered {}/{}", render_count, total_renders);
-                        use std::io::Write;
-                        std::io::stdout().flush().ok();
-                    }
-                    Ok(exit_status) => {
-                        println!(
-                            "\n  ERROR rendering r{}_v{}: subprocess exited with {:?}",
-                            rot_idx, view_idx, exit_status
-                        );
-                    }
-                    Err(e) => {
-                        println!(
-                            "\n  ERROR rendering r{}_v{}: failed to spawn subprocess: {:?}",
-                            rot_idx, view_idx, e
-                        );
-                    }
+            for (view_idx, output) in outputs.iter().enumerate() {
+                if output.status != RenderStatus::Success {
+                    return Err(format!(
+                        "Render failed for {} r{}_v{:02}: {:?}",
+                        object_id, rot_idx, view_idx, output.error_message
+                    )
+                    .into());
                 }
+
+                let rgba_file = format!("r{}_v{:02}.png", rot_idx, view_idx);
+                let depth_file = format!("r{}_v{:02}.depth", rot_idx, view_idx);
+                save_batch_render_output(
+                    output,
+                    &object_output.join(&rgba_file),
+                    &object_output.join(&depth_file),
+                )?;
+
+                let camera_pos = output.request.viewpoint.translation;
+                object_renders.push(RenderMetadata {
+                    object_id: object_id.clone(),
+                    rotation_index: rot_idx,
+                    viewpoint_index: view_idx,
+                    // Convert f64 rotation to f32 for JSON serialization
+                    rotation_euler: [
+                        rotation.pitch as f32,
+                        rotation.yaw as f32,
+                        rotation.roll as f32,
+                    ],
+                    camera_position: [camera_pos.x, camera_pos.y, camera_pos.z],
+                    rgba_file,
+                    depth_file,
+                });
+
+                render_count += 1;
+                print!("\r  Rendered {}/{}", render_count, total_renders);
+                use std::io::Write;
+                std::io::stdout().flush().ok();
             }
         }
         println!();
@@ -378,6 +377,35 @@ fn run_batch_render_impl(args: &[String]) -> Result<(), Box<dyn std::error::Erro
     println!("Output directory: {:?}", output_path);
     println!("\nTo use in tests:");
     println!("  let fixtures = TestFixtures::load(\"test_fixtures/renders\");");
+
+    Ok(())
+}
+
+fn save_batch_render_output(
+    output: &BatchRenderOutput,
+    rgba_path: &Path,
+    depth_path: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(parent) = rgba_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    image::save_buffer(
+        rgba_path,
+        &output.rgba,
+        output.width,
+        output.height,
+        image::ColorType::Rgba8,
+    )?;
+
+    if let Some(parent) = depth_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let depth_bytes: Vec<u8> = output
+        .depth
+        .iter()
+        .flat_map(|depth| depth.to_le_bytes())
+        .collect();
+    fs::write(depth_path, depth_bytes)?;
 
     Ok(())
 }

--- a/src/fixtures.rs
+++ b/src/fixtures.rs
@@ -249,7 +249,9 @@ impl TestFixtures {
 
         // Load depth from binary
         let depth_path = self.root.join(object_id).join(&render_meta.depth_file);
-        let depth = load_depth_binary(&depth_path)?;
+        let expected_depth_values =
+            (self.metadata.resolution[0] as usize) * (self.metadata.resolution[1] as usize);
+        let depth = load_depth_binary(&depth_path, expected_depth_values)?;
 
         // Build camera transform from position (looking at origin)
         let pos = render_meta.camera_position;
@@ -314,20 +316,37 @@ fn load_rgba_png(path: &Path) -> Result<Vec<u8>, FixtureError> {
     Ok(rgba.into_raw())
 }
 
-/// Load depth data from binary f32 file and convert to f64 for TBP precision
-fn load_depth_binary(path: &Path) -> Result<Vec<f64>, FixtureError> {
+/// Load depth data from binary f32 or f64 file and normalize to f64 for TBP precision.
+fn load_depth_binary(path: &Path, expected_values: usize) -> Result<Vec<f64>, FixtureError> {
     let bytes = fs::read(path)?;
 
-    // Convert from little-endian bytes to f32, then to f64 for TBP precision
-    let depth: Vec<f64> = bytes
-        .chunks_exact(4)
-        .map(|chunk| {
-            let arr: [u8; 4] = chunk.try_into().unwrap();
-            f32::from_le_bytes(arr) as f64
-        })
-        .collect();
+    if bytes.len() == expected_values * std::mem::size_of::<f64>() {
+        return Ok(bytes
+            .chunks_exact(8)
+            .map(|chunk| {
+                let arr: [u8; 8] = chunk.try_into().unwrap();
+                f64::from_le_bytes(arr)
+            })
+            .collect());
+    }
 
-    Ok(depth)
+    if bytes.len() == expected_values * std::mem::size_of::<f32>() {
+        return Ok(bytes
+            .chunks_exact(4)
+            .map(|chunk| {
+                let arr: [u8; 4] = chunk.try_into().unwrap();
+                f32::from_le_bytes(arr) as f64
+            })
+            .collect());
+    }
+
+    Err(FixtureError::InvalidMetadata(format!(
+        "Depth file {} has {} bytes, expected {} f32 values or {} f64 values",
+        path.display(),
+        bytes.len(),
+        expected_values,
+        expected_values
+    )))
 }
 
 #[cfg(test)]
@@ -424,7 +443,7 @@ mod tests {
     }
 
     #[test]
-    fn test_load_depth_binary() {
+    fn test_load_depth_binary_f32() {
         let temp_dir = TempDir::new().unwrap();
         let depth_path = temp_dir.path().join("test.depth");
 
@@ -434,12 +453,25 @@ mod tests {
         fs::write(&depth_path, &bytes).unwrap();
 
         // Load and verify
-        let loaded = load_depth_binary(&depth_path).unwrap();
+        let loaded = load_depth_binary(&depth_path, depths.len()).unwrap();
         assert_eq!(loaded.len(), 4);
         assert!((loaded[0] - 0.5).abs() < 0.001);
         assert!((loaded[1] - 1.0).abs() < 0.001);
         assert!((loaded[2] - 2.0).abs() < 0.001);
         assert!((loaded[3] - 10.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_load_depth_binary_f64() {
+        let temp_dir = TempDir::new().unwrap();
+        let depth_path = temp_dir.path().join("test.depth");
+
+        let depths: Vec<f64> = vec![0.5, 1.0, 2.0, 10.0];
+        let bytes: Vec<u8> = depths.iter().flat_map(|f| f.to_le_bytes()).collect();
+        fs::write(&depth_path, &bytes).unwrap();
+
+        let loaded = load_depth_binary(&depth_path, depths.len()).unwrap();
+        assert_eq!(loaded, depths);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,9 +129,23 @@ pub mod ycb {
         Ok(())
     }
 
-    /// Check if YCB models exist at the given path
+    /// Return object IDs whose standard `google_16k` mesh or texture is missing.
+    pub fn missing_objects<P: AsRef<Path>>(output_dir: P, object_ids: &[&str]) -> Vec<String> {
+        ycbust::validate_objects(output_dir.as_ref(), object_ids)
+            .into_iter()
+            .filter(|validation| !validation.is_complete())
+            .map(|validation| validation.name)
+            .collect()
+    }
+
+    /// Check if all requested YCB objects exist at the given path.
+    pub fn objects_exist<P: AsRef<Path>>(output_dir: P, object_ids: &[&str]) -> bool {
+        missing_objects(output_dir, object_ids).is_empty()
+    }
+
+    /// Check if the representative YCB models exist at the given path.
     pub fn models_exist<P: AsRef<Path>>(output_dir: P) -> bool {
-        ycbust::object_mesh_path(output_dir.as_ref(), "003_cracker_box").exists()
+        objects_exist(output_dir, REPRESENTATIVE_OBJECTS)
     }
 
     /// Get the path to a specific YCB object's OBJ file
@@ -563,17 +577,23 @@ impl RenderConfig {
     ///
     /// TBP ref: `transforms.py:440` `fx = np.tan(hfov[i] / 2.0) / zoom`
     pub fn intrinsics(&self) -> CameraIntrinsics {
+        self.intrinsics_for_dimensions(self.width, self.height)
+    }
+
+    /// Compute camera intrinsics for a captured image size using this config's
+    /// projection parameters.
+    pub fn intrinsics_for_dimensions(&self, width: u32, height: u32) -> CameraIntrinsics {
         let base_hfov_rad = 90.0_f64.to_radians();
         // TBP normalized focal length: fx_norm = tan(hfov/2) / zoom
         let fx_norm = (base_hfov_rad / 2.0).tan() / self.zoom as f64;
         // Convert to pixel focal length: fx_pixel = (width/2) / fx_norm
-        let fx = (self.width as f64 / 2.0) / fx_norm;
-        let fy = fx; // Square pixels (TBP adjusts fy for aspect ratio, but we use 64x64)
+        let fx = (width as f64 / 2.0) / fx_norm;
+        let fy = (height as f64 / 2.0) / fx_norm;
 
         CameraIntrinsics {
             focal_length: [fx, fy],
-            principal_point: [self.width as f64 / 2.0, self.height as f64 / 2.0],
-            image_size: [self.width, self.height],
+            principal_point: [width as f64 / 2.0, height as f64 / 2.0],
+            image_size: [width, height],
         }
     }
 }
@@ -1391,6 +1411,31 @@ mod tests {
         // Square pixels: fx == fy.
         assert_eq!(intrinsics.focal_length[0], intrinsics.focal_length[1]);
         assert!(intrinsics.focal_length[0] > 0.0);
+    }
+
+    #[test]
+    fn test_render_config_intrinsics_for_dimensions_matches_default_size() {
+        let config = RenderConfig::tbp_default();
+        assert_eq!(
+            config.intrinsics_for_dimensions(config.width, config.height),
+            config.intrinsics()
+        );
+    }
+
+    #[test]
+    fn test_render_config_intrinsics_follow_projection_formula() {
+        let config = RenderConfig {
+            width: 64,
+            height: 32,
+            zoom: 4.0,
+            ..RenderConfig::tbp_default()
+        };
+        let intrinsics = config.intrinsics();
+
+        assert!((intrinsics.focal_length[0] - 128.0).abs() < 1e-9);
+        assert!((intrinsics.focal_length[1] - 64.0).abs() < 1e-9);
+        assert_eq!(intrinsics.principal_point, [32.0, 16.0]);
+        assert_eq!(intrinsics.image_size, [64, 32]);
     }
 
     #[test]

--- a/src/render.rs
+++ b/src/render.rs
@@ -1885,16 +1885,7 @@ fn extract_and_exit(
         let width = state.image_width;
         let height = state.image_height;
 
-        // Compute intrinsics based on actual dimensions (f64 for TBP precision)
-        let config = &request.config;
-        let intrinsics = crate::CameraIntrinsics {
-            focal_length: [
-                width as f64 * config.zoom as f64,
-                height as f64 * config.zoom as f64,
-            ],
-            principal_point: [width as f64 / 2.0, height as f64 / 2.0],
-            image_size: [width, height],
-        };
+        let intrinsics = request.config.intrinsics_for_dimensions(width, height);
 
         let output = RenderOutput {
             rgba: rgba.clone(),
@@ -2220,16 +2211,7 @@ fn extract_and_exit_headless(
         let width = state.image_width;
         let height = state.image_height;
 
-        // Compute intrinsics (f64 for TBP precision)
-        let config = &request.config;
-        let intrinsics = crate::CameraIntrinsics {
-            focal_length: [
-                width as f64 * config.zoom as f64,
-                height as f64 * config.zoom as f64,
-            ],
-            principal_point: [width as f64 / 2.0, height as f64 / 2.0],
-            image_size: [width, height],
-        };
+        let intrinsics = request.config.intrinsics_for_dimensions(width, height);
 
         let output = RenderOutput {
             rgba: rgba.clone(),
@@ -2304,15 +2286,7 @@ fn extract_and_continue_headless_batch(
         let width = state.image_width;
         let height = state.image_height;
 
-        let config = &request.config;
-        let intrinsics = crate::CameraIntrinsics {
-            focal_length: [
-                width as f64 * config.zoom as f64,
-                height as f64 * config.zoom as f64,
-            ],
-            principal_point: [width as f64 / 2.0, height as f64 / 2.0],
-            image_size: [width, height],
-        };
+        let intrinsics = request.config.intrinsics_for_dimensions(width, height);
 
         let output = RenderOutput {
             rgba: rgba.clone(),

--- a/tests/ycb_public_api.rs
+++ b/tests/ycb_public_api.rs
@@ -3,6 +3,7 @@ use bevy_sensor::{
     REPRESENTATIVE_OBJECTS as REEXPORTED_REPRESENTATIVE_OBJECTS,
     TBP_STANDARD_OBJECTS as REEXPORTED_TBP_STANDARD_OBJECTS,
 };
+use std::fs;
 use std::path::Path;
 
 #[test]
@@ -20,4 +21,36 @@ fn public_ycb_constants_expose_expected_downstream_sets() {
 fn public_ycb_download_objects_is_callable_without_internal_imports() {
     let future = ycb::download_objects(Path::new("."), &["003_cracker_box"]);
     drop(future);
+}
+
+#[test]
+fn public_ycb_objects_exist_validates_requested_set() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mesh = ycb::object_mesh_path(dir.path(), "003_cracker_box");
+    let texture = ycb::object_texture_path(dir.path(), "003_cracker_box");
+    fs::create_dir_all(mesh.parent().expect("mesh parent")).expect("create object dir");
+    fs::write(&mesh, b"").expect("write mesh marker");
+    fs::write(&texture, b"").expect("write texture marker");
+
+    assert!(ycb::objects_exist(dir.path(), &["003_cracker_box"]));
+    assert!(!ycb::objects_exist(
+        dir.path(),
+        &["003_cracker_box", "004_sugar_box"]
+    ));
+    assert_eq!(
+        ycb::missing_objects(dir.path(), &["003_cracker_box", "004_sugar_box"]),
+        vec!["004_sugar_box".to_string()]
+    );
+}
+
+#[test]
+fn public_ycb_models_exist_requires_representative_set() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mesh = ycb::object_mesh_path(dir.path(), "003_cracker_box");
+    let texture = ycb::object_texture_path(dir.path(), "003_cracker_box");
+    fs::create_dir_all(mesh.parent().expect("mesh parent")).expect("create object dir");
+    fs::write(&mesh, b"").expect("write mesh marker");
+    fs::write(&texture, b"").expect("write texture marker");
+
+    assert!(!ycb::models_exist(dir.path()));
 }


### PR DESCRIPTION
﻿## Summary

- validate requested YCB object sets before prerendering and expose public helpers for exact object checks
- align rendered output intrinsics with `RenderConfig` projection helpers
- render prerender batches in-process through `render_batch` instead of spawning one subprocess per viewpoint
- load both f32 and f64 fixture depth files for backward-compatible test fixtures
- add a Windows compile-only CI job using low-memory build settings

## Verification

Ran locally on Windows with `CARGO_BUILD_JOBS=1`, `RUSTFLAGS=-Cdebuginfo=0`, `CARGO_TARGET_DIR=D:\codex-bevy-sensor-target`, and temp dirs on `D:` because `C:` is full:

- `cargo check --bin prerender`
- `cargo test test_load_depth_binary --lib`
- `cargo test fixtures::tests --lib`
- `cargo test --lib`
- `cargo test --test ycb_public_api`
- `cargo check --all-targets`
- `cargo test --tests`
- `cargo check --locked --all-targets`

Closes #70.
Closes #71.
Closes #72.
