### PR TITLE
[codex] Add TBP surface targeting and render health APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,6 +633,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tobj",
  "tokio",
  "wgpu 24.0.5",
  "ycbust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ bevy = { version = "0.15.3", default-features = false, features = [
     "zstd",            # Compression for ktx2
 ] }
 bevy_obj = { version = "0.15", features = ["scene"] }
+tobj = "4.0"
 ycbust = { version = "0.4.1", features = ["blocking"] }
 image = "0.25"  # For saving PNG/depth images
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -78,6 +78,22 @@ Render specific objects:
 just render-batch "003_cracker_box,005_tomato_soup_can"
 ```
 
+Validate center foreground hits before a longer NeoCortx parity run:
+```bash
+cargo run --bin prerender -- \
+  --validate-center-hit \
+  --data-dir /tmp/ycb \
+  --objects "033_spatula,057_racquetball,063-b_marbles,065-e_cups,073-f_lego_duplo" \
+  --target mesh-center \
+  --rotation-schedule tbp-parity \
+  --validation-report target/center_hit_validation_timeout_objects.json
+```
+
+The validation command exits non-zero when any object rotation has zero center-foreground hits.
+Batch prerenders also accept `--target mesh-center` and write the targeting policy,
+mesh bounds, target point, camera pose, and render-health summary into the generated
+manifest/index JSON.
+
 ### Library (Rust)
 
 Add to your `Cargo.toml`:
@@ -102,6 +118,34 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let output = render_to_buffer(object_path, &viewpoint, &rotation, &config)?;
     
     println!("Captured {}x{} image", output.width, output.height);
+    Ok(())
+}
+```
+
+For YCB parity runs where the mesh's visual center is not the source origin,
+generate the same TBP orbit around the rotated mesh AABB center:
+
+```rust
+use bevy_sensor::{
+    generate_ycb_object_centered_viewpoints, render_to_buffer, ObjectRotation, RenderConfig,
+    ViewpointConfig,
+};
+use std::path::Path;
+
+fn render_centered() -> Result<(), Box<dyn std::error::Error>> {
+    let object_path = Path::new("/tmp/ycb/033_spatula");
+    let config = RenderConfig::tbp_default();
+    let rotation = ObjectRotation::new(0.0, 90.0, 0.0);
+    let viewpoints = generate_ycb_object_centered_viewpoints(
+        object_path,
+        &ViewpointConfig::default(),
+        &rotation,
+    )?;
+    let output = render_to_buffer(object_path, &viewpoints[0], &rotation, &config)?;
+
+    let health = output.health();
+    let surface_point = output.center_surface_point_world();
+    println!("{:?} {:?}", health.center_foreground, surface_point);
     Ok(())
 }
 ```

--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ cargo run --bin prerender -- \
 The validation command exits non-zero when any object rotation has zero center-foreground hits.
 Batch prerenders also accept `--target mesh-center` and write the targeting policy,
 mesh bounds, target point, camera pose, and render-health summary into the generated
-manifest/index JSON.
+manifest/index JSON. Live `RenderOutput` and `BatchRenderOutput` values also carry
+`target_point` and `targeting_policy`, so consumers do not need to recompute the
+rotated mesh-center pivot from manifest metadata.
 
 ### Library (Rust)
 
@@ -127,8 +129,8 @@ generate the same TBP orbit around the rotated mesh AABB center:
 
 ```rust
 use bevy_sensor::{
-    generate_ycb_object_centered_viewpoints, render_to_buffer, ObjectRotation, RenderConfig,
-    ViewpointConfig,
+    generate_targeted_viewpoints, render_to_buffer_with_target, ObjectRotation, RenderConfig,
+    TargetingPolicy, ViewpointConfig,
 };
 use std::path::Path;
 
@@ -136,16 +138,27 @@ fn render_centered() -> Result<(), Box<dyn std::error::Error>> {
     let object_path = Path::new("/tmp/ycb/033_spatula");
     let config = RenderConfig::tbp_default();
     let rotation = ObjectRotation::new(0.0, 90.0, 0.0);
-    let viewpoints = generate_ycb_object_centered_viewpoints(
+    let targeted = generate_targeted_viewpoints(
         object_path,
         &ViewpointConfig::default(),
         &rotation,
+        &TargetingPolicy::MeshCenter,
     )?;
-    let output = render_to_buffer(object_path, &viewpoints[0], &rotation, &config)?;
+    let output = render_to_buffer_with_target(
+        object_path,
+        &targeted.viewpoints[0],
+        &rotation,
+        &config,
+        targeted.target_point,
+        targeted.policy.clone(),
+    )?;
 
     let health = output.health();
     let surface_point = output.center_surface_point_world();
-    println!("{:?} {:?}", health.center_foreground, surface_point);
+    println!(
+        "{:?} {:?} {:?}",
+        output.target_point, health.center_foreground, surface_point
+    );
     Ok(())
 }
 ```

--- a/examples/batch_render_neocortx.rs
+++ b/examples/batch_render_neocortx.rs
@@ -12,7 +12,7 @@
 use bevy_sensor::{
     create_batch_renderer, generate_viewpoints, queue_render_request, render_next_in_batch,
     BatchRenderConfig, BatchRenderRequest, ObjectRotation, RenderConfig, RenderStatus,
-    ViewpointConfig,
+    TargetingPolicy, Vec3, ViewpointConfig,
 };
 use std::path::PathBuf;
 use std::time::Instant;
@@ -67,6 +67,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     viewpoint: *viewpoint,
                     object_rotation: rotation.clone(),
                     render_config: render_config.clone(),
+                    target_point: Vec3::ZERO,
+                    targeting_policy: TargetingPolicy::Origin,
                 },
             )?;
             total_queued += 1;

--- a/examples/persistent_per_step.rs
+++ b/examples/persistent_per_step.rs
@@ -22,7 +22,8 @@
 
 use bevy_sensor::{
     batch::BatchRenderRequest, generate_viewpoints, render_to_buffer, BatchRenderConfig,
-    ObjectRotation, PersistentRenderer, RenderConfig, RenderSession, ViewpointConfig,
+    ObjectRotation, PersistentRenderer, RenderConfig, RenderSession, TargetingPolicy, Vec3,
+    ViewpointConfig,
 };
 use std::path::PathBuf;
 use std::time::Instant;
@@ -108,6 +109,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             viewpoint: vp,
             object_rotation: rotation.clone(),
             render_config: render_config.clone(),
+            target_point: Vec3::ZERO,
+            targeting_policy: TargetingPolicy::Origin,
         }])?;
     }
     let session_per_call = t1.elapsed();

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -41,7 +41,7 @@
 //! }
 //! ```
 
-use crate::{CameraIntrinsics, ObjectRotation, RenderConfig, RenderOutput};
+use crate::{CameraIntrinsics, ObjectRotation, RenderConfig, RenderHealth, RenderOutput};
 use bevy::prelude::Transform;
 use std::collections::VecDeque;
 use std::path::PathBuf;
@@ -112,6 +112,8 @@ pub struct BatchRenderOutput {
     pub height: u32,
     /// Camera intrinsics used
     pub intrinsics: CameraIntrinsics,
+    /// Cheap diagnostics derived from the rendered depth buffer
+    pub health: RenderHealth,
     /// Status of this render
     pub status: RenderStatus,
     /// Error message if status is Failed or PartialFailure
@@ -157,6 +159,7 @@ impl BatchRenderOutput {
 
     /// Convert from RenderOutput, copying all fields
     pub fn from_render_output(request: BatchRenderRequest, output: RenderOutput) -> Self {
+        let health = output.health_with_far_plane(request.render_config.far_plane as f64);
         Self {
             request,
             rgba: output.rgba,
@@ -164,6 +167,7 @@ impl BatchRenderOutput {
             width: output.width,
             height: output.height,
             intrinsics: output.intrinsics,
+            health,
             status: RenderStatus::Success,
             error_message: None,
         }
@@ -381,6 +385,17 @@ mod tests {
             width: 2,
             height: 2,
             intrinsics: RenderConfig::tbp_default().intrinsics(),
+            health: RenderHealth {
+                center_pixel: Some([1, 1]),
+                center_depth: Some(1.0),
+                center_foreground: true,
+                foreground_pixel_count: 4,
+                foreground_coverage: 1.0,
+                center_5x5_foreground_count: 4,
+                nearest_foreground_pixel: Some([1, 1]),
+                nearest_foreground_depth: Some(1.0),
+                nearest_foreground_distance_px: Some(0.0),
+            },
             status: RenderStatus::Success,
             error_message: None,
         };

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -12,6 +12,7 @@
 //! use bevy_sensor::{
 //!     create_batch_renderer, queue_render_request, render_next_in_batch,
 //!     batch::BatchRenderRequest, BatchRenderConfig, RenderConfig, ObjectRotation,
+//!     TargetingPolicy, Vec3,
 //! };
 //! use std::path::PathBuf;
 //!
@@ -27,6 +28,8 @@
 //!             viewpoint,
 //!             object_rotation: rotation.clone(),
 //!             render_config: RenderConfig::tbp_default(),
+//!             target_point: Vec3::ZERO,
+//!             targeting_policy: TargetingPolicy::Origin,
 //!         })?;
 //!     }
 //! }
@@ -41,8 +44,10 @@
 //! }
 //! ```
 
-use crate::{CameraIntrinsics, ObjectRotation, RenderConfig, RenderHealth, RenderOutput};
-use bevy::prelude::Transform;
+use crate::{
+    CameraIntrinsics, ObjectRotation, RenderConfig, RenderHealth, RenderOutput, TargetingPolicy,
+};
+use bevy::prelude::{Transform, Vec3};
 use std::collections::VecDeque;
 use std::path::PathBuf;
 
@@ -84,6 +89,10 @@ pub struct BatchRenderRequest {
     pub object_rotation: ObjectRotation,
     /// Render configuration (resolution, lighting, etc.)
     pub render_config: RenderConfig,
+    /// Point the camera was intended to target for this render.
+    pub target_point: Vec3,
+    /// Policy used to derive `target_point`.
+    pub targeting_policy: TargetingPolicy,
 }
 
 /// Status of a single render in a batch.
@@ -112,6 +121,10 @@ pub struct BatchRenderOutput {
     pub height: u32,
     /// Camera intrinsics used
     pub intrinsics: CameraIntrinsics,
+    /// Point the camera was intended to target for this render.
+    pub target_point: Vec3,
+    /// Policy used to derive `target_point`.
+    pub targeting_policy: TargetingPolicy,
     /// Cheap diagnostics derived from the rendered depth buffer
     pub health: RenderHealth,
     /// Status of this render
@@ -157,9 +170,11 @@ impl BatchRenderOutput {
         image
     }
 
-    /// Convert from RenderOutput, copying all fields
+    /// Convert from RenderOutput, carrying request-level target metadata.
     pub fn from_render_output(request: BatchRenderRequest, output: RenderOutput) -> Self {
         let health = output.health_with_far_plane(request.render_config.far_plane as f64);
+        let target_point = request.target_point;
+        let targeting_policy = request.targeting_policy.clone();
         Self {
             request,
             rgba: output.rgba,
@@ -167,6 +182,8 @@ impl BatchRenderOutput {
             width: output.width,
             height: output.height,
             intrinsics: output.intrinsics,
+            target_point,
+            targeting_policy,
             health,
             status: RenderStatus::Success,
             error_message: None,
@@ -334,6 +351,8 @@ mod tests {
             viewpoint: Transform::default(),
             object_rotation: ObjectRotation::identity(),
             render_config: RenderConfig::tbp_default(),
+            target_point: Vec3::ZERO,
+            targeting_policy: TargetingPolicy::Origin,
         };
         assert!(renderer.queue_request(request).is_ok());
         assert_eq!(renderer.pending_count(), 1);
@@ -352,6 +371,8 @@ mod tests {
             viewpoint: Transform::default(),
             object_rotation: ObjectRotation::identity(),
             render_config: RenderConfig::tbp_default(),
+            target_point: Vec3::ZERO,
+            targeting_policy: TargetingPolicy::Origin,
         };
 
         assert!(renderer.queue_request(request.clone()).is_ok());
@@ -368,6 +389,8 @@ mod tests {
             viewpoint: Transform::default(),
             object_rotation: ObjectRotation::identity(),
             render_config: RenderConfig::tbp_default(),
+            target_point: Vec3::ZERO,
+            targeting_policy: TargetingPolicy::Origin,
         };
 
         // Create minimal output: 2x2 image
@@ -385,6 +408,8 @@ mod tests {
             width: 2,
             height: 2,
             intrinsics: RenderConfig::tbp_default().intrinsics(),
+            target_point: Vec3::ZERO,
+            targeting_policy: TargetingPolicy::Origin,
             health: RenderHealth {
                 center_pixel: Some([1, 1]),
                 center_depth: Some(1.0),
@@ -404,5 +429,39 @@ mod tests {
         assert_eq!(rgb.len(), 2); // 2 rows
         assert_eq!(rgb[0].len(), 2); // 2 cols
         assert_eq!(rgb[0][0], [255, 0, 0]); // Red
+    }
+
+    #[test]
+    fn test_batch_render_output_carries_request_target_metadata() {
+        let target_point = Vec3::new(0.25, -0.125, 0.5);
+        let request = BatchRenderRequest {
+            object_dir: "/tmp/test".into(),
+            viewpoint: Transform::default(),
+            object_rotation: ObjectRotation::identity(),
+            render_config: RenderConfig::tbp_default(),
+            target_point,
+            targeting_policy: TargetingPolicy::MeshCenter,
+        };
+        let output = RenderOutput {
+            rgba: vec![0u8; 4],
+            depth: vec![1.0],
+            width: 1,
+            height: 1,
+            intrinsics: RenderConfig::tbp_default().intrinsics(),
+            camera_transform: Transform::default(),
+            object_rotation: ObjectRotation::identity(),
+            target_point: Vec3::ZERO,
+            targeting_policy: TargetingPolicy::Origin,
+        };
+
+        let batch_output = BatchRenderOutput::from_render_output(request, output);
+
+        assert_eq!(batch_output.target_point, target_point);
+        assert_eq!(batch_output.targeting_policy, TargetingPolicy::MeshCenter);
+        assert_eq!(batch_output.request.target_point, target_point);
+        assert_eq!(
+            batch_output.request.targeting_policy,
+            TargetingPolicy::MeshCenter
+        );
     }
 }

--- a/src/bin/prerender.rs
+++ b/src/bin/prerender.rs
@@ -456,6 +456,8 @@ fn run_batch_render_impl(args: &[String]) -> Result<(), Box<dyn std::error::Erro
                     viewpoint: *viewpoint,
                     object_rotation: rotation.clone(),
                     render_config: render_config.clone(),
+                    target_point: targeted.target_point,
+                    targeting_policy: target_policy.clone(),
                 })
                 .collect();
 
@@ -494,8 +496,8 @@ fn run_batch_render_impl(args: &[String]) -> Result<(), Box<dyn std::error::Erro
                     ],
                     camera_position: [camera_pos.x, camera_pos.y, camera_pos.z],
                     camera_rotation_xyzw: [camera_rot.x, camera_rot.y, camera_rot.z, camera_rot.w],
-                    target_point: targeted.target_point.to_array(),
-                    targeting_policy: target_policy.clone(),
+                    target_point: output.target_point.to_array(),
+                    targeting_policy: output.targeting_policy.clone(),
                     mesh_bounds: targeted.mesh_bounds.map(MeshBoundsMetadata::from),
                     health: output.health.clone(),
                     rgba_file,

--- a/src/bin/prerender.rs
+++ b/src/bin/prerender.rs
@@ -4,10 +4,13 @@
 //! The output can be committed to the repository for CI/CD testing.
 //!
 //! Usage:
-//!   cargo run --bin prerender -- [--output-dir <path>] [--objects <obj1,obj2>]
+//!   cargo run --bin prerender -- [--output-dir <path>] [--objects <obj1,obj2>] [--target origin|mesh-center]
+//!   cargo run --bin prerender -- --validate-center-hit --objects <obj1,obj2> --target mesh-center
 //!
 //! Default output: test_fixtures/renders/
 //! Default objects: 003_cracker_box, 005_tomato_soup_can
+//! Default batch target: origin
+//! Default validation target: mesh-center
 //!
 //! For single-render mode:
 //!   cargo run --bin prerender -- --single-render --object <name> --rotation <idx> --viewpoint <idx> --output <dir>
@@ -15,8 +18,9 @@
 use bevy_sensor::ycb;
 use bevy_sensor::ycbust;
 use bevy_sensor::{
-    generate_viewpoints, render_batch, BatchRenderConfig, BatchRenderOutput, BatchRenderRequest,
-    ObjectRotation, RenderConfig, RenderStatus, ViewpointConfig,
+    generate_targeted_viewpoints, render_batch, validate_center_hits, BatchRenderConfig,
+    BatchRenderOutput, BatchRenderRequest, MeshBoundsMetadata, ObjectRotation, RenderConfig,
+    RenderHealth, RenderStatus, TargetingPolicy, ViewpointConfig, RENDERER_POLICY_VERSION,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -28,6 +32,10 @@ use std::path::{Path, PathBuf};
 pub struct DatasetMetadata {
     /// Version of the dataset format
     pub version: String,
+    /// bevy-sensor crate version that generated the dataset
+    pub crate_version: String,
+    /// Renderer/targeting-policy version
+    pub renderer_policy_version: String,
     /// Objects included in this dataset
     pub objects: Vec<String>,
     /// Number of viewpoints per rotation
@@ -38,6 +46,12 @@ pub struct DatasetMetadata {
     pub renders_per_object: usize,
     /// Image resolution
     pub resolution: [u32; 2],
+    /// Named image width for manifest consumers
+    pub resolution_width: u32,
+    /// Named image height for manifest consumers
+    pub resolution_height: u32,
+    /// Targeting policy used for viewpoint generation
+    pub targeting_policy: TargetingPolicy,
     /// Camera intrinsics
     pub intrinsics: IntrinsicsMetadata,
     /// Viewpoint configuration
@@ -68,6 +82,11 @@ pub struct RenderMetadata {
     pub viewpoint_index: usize,
     pub rotation_euler: [f32; 3],
     pub camera_position: [f32; 3],
+    pub camera_rotation_xyzw: [f32; 4],
+    pub target_point: [f32; 3],
+    pub targeting_policy: TargetingPolicy,
+    pub mesh_bounds: Option<MeshBoundsMetadata>,
+    pub health: RenderHealth,
     pub rgba_file: String,
     pub depth_file: String,
 }
@@ -86,6 +105,11 @@ fn main() {
     // Keep single-render mode available for scripts that render one capture.
     if args.iter().any(|a| a == "--single-render") {
         run_single_render(&args);
+        return;
+    }
+
+    if args.iter().any(|a| a == "--validate-center-hit") {
+        run_center_hit_validation(&args);
         return;
     }
 
@@ -115,6 +139,7 @@ fn run_single_render_impl(args: &[String]) -> Result<(), Box<dyn std::error::Err
     let output_dir =
         parse_arg(args, "--output").unwrap_or_else(|| "test_fixtures/renders".to_string());
     let data_dir_str = parse_arg(args, "--data-dir").unwrap_or_else(|| "/tmp/ycb".to_string());
+    let target_policy = parse_target_policy(args, "origin")?;
 
     let ycb_dir = PathBuf::from(&data_dir_str);
 
@@ -126,11 +151,18 @@ fn run_single_render_impl(args: &[String]) -> Result<(), Box<dyn std::error::Err
 
     let render_config = RenderConfig::tbp_default();
     let viewpoint_config = ViewpointConfig::default();
-    let rotations = ObjectRotation::tbp_benchmark_rotations();
-    let viewpoints = generate_viewpoints(&viewpoint_config);
+    let rotations = rotations_from_args(args)?;
 
     let rotation = &rotations[rotation_idx];
-    let viewpoint = &viewpoints[viewpoint_idx];
+    let targeted =
+        generate_targeted_viewpoints(&object_dir, &viewpoint_config, rotation, &target_policy)?;
+    let viewpoint = targeted.viewpoints.get(viewpoint_idx).ok_or_else(|| {
+        format!(
+            "Error: --viewpoint {} out of range for {} generated viewpoints",
+            viewpoint_idx,
+            targeted.viewpoints.len()
+        )
+    })?;
 
     // Create output directory
     let object_output = PathBuf::from(&output_dir).join(&object_id);
@@ -162,6 +194,98 @@ fn run_single_render_impl(args: &[String]) -> Result<(), Box<dyn std::error::Err
     Ok(())
 }
 
+/// Run center-hit validation without saving render outputs.
+fn run_center_hit_validation(args: &[String]) {
+    if let Err(e) = run_center_hit_validation_impl(args) {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    }
+}
+
+fn run_center_hit_validation_impl(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    let data_dir_str = parse_arg(args, "--data-dir").unwrap_or_else(|| "/tmp/ycb".to_string());
+    let objects_arg = parse_arg(args, "--objects");
+    let target_policy = parse_target_policy(args, "mesh-center")?;
+    let rotations = rotations_from_args(args)?;
+
+    let objects: Vec<String> = if let Some(objs) = objects_arg {
+        objs.split(',')
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .collect()
+    } else {
+        CI_TEST_OBJECTS.iter().map(|s| s.to_string()).collect()
+    };
+
+    println!("=== bevy-sensor Center-Hit Validation ===");
+    println!("Data directory: {}", data_dir_str);
+    println!("Objects: {:?}", objects);
+    println!("Targeting: {}", target_policy.label());
+    println!("Rotations: {}", rotations.len());
+
+    let ycb_dir = PathBuf::from(&data_dir_str);
+    let object_refs: Vec<&str> = objects.iter().map(String::as_str).collect();
+    ensure_ycb_objects(&ycb_dir, &object_refs)?;
+    let ycb_dir = fs::canonicalize(&ycb_dir).unwrap_or(ycb_dir);
+
+    let render_config = RenderConfig::tbp_default();
+    let viewpoint_config = ViewpointConfig::default();
+    let mut reports = Vec::with_capacity(objects.len());
+
+    for object_id in &objects {
+        let object_dir = ycb_dir.join(object_id);
+        println!("\n--- Validating {} ---", object_id);
+        let report = validate_center_hits(
+            object_id.clone(),
+            &object_dir,
+            &viewpoint_config,
+            &rotations,
+            &render_config,
+            &target_policy,
+        )?;
+
+        for rotation in &report.rotations {
+            println!(
+                "  rotation {} {:?}: {}/{} center hits",
+                rotation.rotation_index,
+                rotation.rotation_euler,
+                rotation.center_hits,
+                rotation.total_viewpoints
+            );
+        }
+
+        let report_json = serde_json::to_string_pretty(&report)?;
+        println!("{}", report_json);
+
+        if !report.is_valid() {
+            return Err(format!(
+                "{} failed center-hit validation for rotations {:?}",
+                object_id,
+                report.zero_hit_rotations()
+            )
+            .into());
+        }
+
+        reports.push(report);
+    }
+
+    if let Some(report_path) = parse_arg(args, "--validation-report") {
+        let report_path = PathBuf::from(report_path);
+        if let Some(parent) = report_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&report_path, serde_json::to_string_pretty(&reports)?)?;
+        println!("\nSaved validation report to {}", report_path.display());
+    }
+
+    println!(
+        "\nCenter-hit validation passed for {} objects.",
+        reports.len()
+    );
+    Ok(())
+}
+
 /// Run batch rendering (main mode)
 fn run_batch_render(args: &[String]) {
     if let Err(e) = run_batch_render_impl(args) {
@@ -175,9 +299,15 @@ fn run_batch_render_impl(args: &[String]) -> Result<(), Box<dyn std::error::Erro
         parse_arg(args, "--output-dir").unwrap_or_else(|| "test_fixtures/renders".to_string());
     let data_dir_str = parse_arg(args, "--data-dir").unwrap_or_else(|| "/tmp/ycb".to_string());
     let objects_arg = parse_arg(args, "--objects");
+    let target_policy = parse_target_policy(args, "origin")?;
+    let rotations = rotations_from_args(args)?;
 
     let objects: Vec<String> = if let Some(objs) = objects_arg {
-        objs.split(',').map(|s| s.trim().to_string()).collect()
+        objs.split(',')
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .collect()
     } else {
         CI_TEST_OBJECTS.iter().map(|s| s.to_string()).collect()
     };
@@ -186,6 +316,7 @@ fn run_batch_render_impl(args: &[String]) -> Result<(), Box<dyn std::error::Erro
     println!("Output directory: {}", output_dir);
     println!("Data directory: {}", data_dir_str);
     println!("Objects: {:?}", objects);
+    println!("Targeting: {}", target_policy.label());
 
     let ycb_dir = PathBuf::from(&data_dir_str);
     let object_refs: Vec<&str> = objects.iter().map(String::as_str).collect();
@@ -208,30 +339,34 @@ fn run_batch_render_impl(args: &[String]) -> Result<(), Box<dyn std::error::Erro
     // Configuration
     let render_config = RenderConfig::tbp_default();
     let viewpoint_config = ViewpointConfig::default();
-    let rotations = ObjectRotation::tbp_benchmark_rotations();
-    let viewpoints = generate_viewpoints(&viewpoint_config);
+    let viewpoints_per_rotation = viewpoint_config.viewpoint_count();
 
     println!("\nConfiguration:");
     println!(
         "  Resolution: {}x{}",
         render_config.width, render_config.height
     );
-    println!("  Viewpoints: {}", viewpoints.len());
+    println!("  Viewpoints: {}", viewpoints_per_rotation);
     println!("  Rotations: {}", rotations.len());
     println!(
         "  Total renders per object: {}",
-        viewpoints.len() * rotations.len()
+        viewpoints_per_rotation * rotations.len()
     );
 
     // Create dataset metadata
     let intrinsics = render_config.intrinsics();
     let metadata = DatasetMetadata {
-        version: "1.0".to_string(),
+        version: "1.1".to_string(),
+        crate_version: env!("CARGO_PKG_VERSION").to_string(),
+        renderer_policy_version: RENDERER_POLICY_VERSION.to_string(),
         objects: objects.clone(),
-        viewpoints_per_rotation: viewpoints.len(),
+        viewpoints_per_rotation,
         rotations_per_object: rotations.len(),
-        renders_per_object: viewpoints.len() * rotations.len(),
+        renders_per_object: viewpoints_per_rotation * rotations.len(),
         resolution: [render_config.width, render_config.height],
+        resolution_width: render_config.width,
+        resolution_height: render_config.height,
+        targeting_policy: target_policy.clone(),
         intrinsics: IntrinsicsMetadata {
             // Convert f64 intrinsics to f32 for JSON serialization (backward compatible)
             focal_length: [
@@ -297,10 +432,24 @@ fn run_batch_render_impl(args: &[String]) -> Result<(), Box<dyn std::error::Erro
 
         let mut object_renders: Vec<RenderMetadata> = Vec::new();
         let mut render_count = 0;
-        let total_renders = viewpoints.len() * rotations.len();
+        let total_renders = viewpoints_per_rotation * rotations.len();
 
         for (rot_idx, rotation) in rotations.iter().enumerate() {
-            let requests: Vec<BatchRenderRequest> = viewpoints
+            let targeted = generate_targeted_viewpoints(
+                &object_dir,
+                &viewpoint_config,
+                rotation,
+                &target_policy,
+            )
+            .map_err(|e| {
+                format!(
+                    "Failed to generate targeted viewpoints for {} rotation {}: {}",
+                    object_id, rot_idx, e
+                )
+            })?;
+
+            let requests: Vec<BatchRenderRequest> = targeted
+                .viewpoints
                 .iter()
                 .map(|viewpoint| BatchRenderRequest {
                     object_dir: object_dir.clone(),
@@ -332,6 +481,7 @@ fn run_batch_render_impl(args: &[String]) -> Result<(), Box<dyn std::error::Erro
                 )?;
 
                 let camera_pos = output.request.viewpoint.translation;
+                let camera_rot = output.request.viewpoint.rotation;
                 object_renders.push(RenderMetadata {
                     object_id: object_id.clone(),
                     rotation_index: rot_idx,
@@ -343,6 +493,11 @@ fn run_batch_render_impl(args: &[String]) -> Result<(), Box<dyn std::error::Erro
                         rotation.roll as f32,
                     ],
                     camera_position: [camera_pos.x, camera_pos.y, camera_pos.z],
+                    camera_rotation_xyzw: [camera_rot.x, camera_rot.y, camera_rot.z, camera_rot.w],
+                    target_point: targeted.target_point.to_array(),
+                    targeting_policy: target_policy.clone(),
+                    mesh_bounds: targeted.mesh_bounds.map(MeshBoundsMetadata::from),
+                    health: output.health.clone(),
                     rgba_file,
                     depth_file,
                 });
@@ -414,6 +569,40 @@ fn parse_arg(args: &[String], flag: &str) -> Option<String> {
     args.iter()
         .position(|a| a == flag)
         .and_then(|i| args.get(i + 1).cloned())
+}
+
+fn parse_target_policy(
+    args: &[String],
+    default: &str,
+) -> Result<TargetingPolicy, Box<dyn std::error::Error>> {
+    let value = parse_arg(args, "--target").unwrap_or_else(|| default.to_string());
+    match value.as_str() {
+        "origin" => Ok(TargetingPolicy::Origin),
+        "mesh-center" | "mesh_center" => Ok(TargetingPolicy::MeshCenter),
+        other => Err(format!(
+            "Invalid --target '{}'. Supported values: origin, mesh-center",
+            other
+        )
+        .into()),
+    }
+}
+
+fn rotations_from_args(args: &[String]) -> Result<Vec<ObjectRotation>, Box<dyn std::error::Error>> {
+    let schedule =
+        parse_arg(args, "--rotation-schedule").unwrap_or_else(|| "tbp-parity".to_string());
+    match schedule.as_str() {
+        "tbp-parity" | "tbp-benchmark" | "benchmark" => {
+            Ok(ObjectRotation::tbp_benchmark_rotations())
+        }
+        "tbp-known" | "tbp-known-orientations" | "known" | "full" => {
+            Ok(ObjectRotation::tbp_known_orientations())
+        }
+        other => Err(format!(
+            "Invalid --rotation-schedule '{}'. Supported values: tbp-parity, tbp-known",
+            other
+        )
+        .into()),
+    }
 }
 
 fn ensure_ycb_objects(

--- a/src/fixtures.rs
+++ b/src/fixtures.rs
@@ -289,6 +289,12 @@ impl TestFixtures {
             Transform::from_translation(translation)
                 .looking_at(Vec3::new(target[0], target[1], target[2]), Vec3::Y)
         };
+        let target_point = Vec3::from_array(render_meta.target_point.unwrap_or([0.0, 0.0, 0.0]));
+        let targeting_policy = render_meta
+            .targeting_policy
+            .clone()
+            .or_else(|| self.metadata.targeting_policy.clone())
+            .unwrap_or(TargetingPolicy::Origin);
 
         // Build object rotation (convert from f32 metadata to f64)
         let rot = render_meta.rotation_euler;
@@ -303,6 +309,8 @@ impl TestFixtures {
             intrinsics: self.intrinsics(),
             camera_transform,
             object_rotation,
+            target_point,
+            targeting_policy,
         })
     }
 

--- a/src/fixtures.rs
+++ b/src/fixtures.rs
@@ -16,7 +16,7 @@
 //! let depth_image = render.to_depth_image();
 //! ```
 
-use crate::{CameraIntrinsics, RenderOutput};
+use crate::{CameraIntrinsics, MeshBoundsMetadata, RenderHealth, RenderOutput, TargetingPolicy};
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -80,11 +80,21 @@ impl From<serde_json::Error> for FixtureError {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DatasetMetadata {
     pub version: String,
+    #[serde(default)]
+    pub crate_version: Option<String>,
+    #[serde(default)]
+    pub renderer_policy_version: Option<String>,
     pub objects: Vec<String>,
     pub viewpoints_per_rotation: usize,
     pub rotations_per_object: usize,
     pub renders_per_object: usize,
     pub resolution: [u32; 2],
+    #[serde(default)]
+    pub resolution_width: Option<u32>,
+    #[serde(default)]
+    pub resolution_height: Option<u32>,
+    #[serde(default)]
+    pub targeting_policy: Option<TargetingPolicy>,
     pub intrinsics: IntrinsicsMetadata,
     pub viewpoint_config: ViewpointConfigMetadata,
     pub rotations: Vec<[f32; 3]>,
@@ -112,6 +122,16 @@ pub struct RenderMetadata {
     pub viewpoint_index: usize,
     pub rotation_euler: [f32; 3],
     pub camera_position: [f32; 3],
+    #[serde(default)]
+    pub camera_rotation_xyzw: Option<[f32; 4]>,
+    #[serde(default)]
+    pub target_point: Option<[f32; 3]>,
+    #[serde(default)]
+    pub targeting_policy: Option<TargetingPolicy>,
+    #[serde(default)]
+    pub mesh_bounds: Option<MeshBoundsMetadata>,
+    #[serde(default)]
+    pub health: Option<RenderHealth>,
     pub rgba_file: String,
     pub depth_file: String,
 }
@@ -253,10 +273,22 @@ impl TestFixtures {
             (self.metadata.resolution[0] as usize) * (self.metadata.resolution[1] as usize);
         let depth = load_depth_binary(&depth_path, expected_depth_values)?;
 
-        // Build camera transform from position (looking at origin)
+        // Build camera transform from position. New manifests carry the exact
+        // render rotation; older manifests only recorded origin-targeted
+        // camera positions, so reconstruct with a target fallback.
         let pos = render_meta.camera_position;
-        let camera_transform =
-            Transform::from_xyz(pos[0], pos[1], pos[2]).looking_at(Vec3::ZERO, Vec3::Y);
+        let translation = Vec3::new(pos[0], pos[1], pos[2]);
+        let camera_transform = if let Some(q) = render_meta.camera_rotation_xyzw {
+            Transform {
+                translation,
+                rotation: Quat::from_xyzw(q[0], q[1], q[2], q[3]),
+                ..Default::default()
+            }
+        } else {
+            let target = render_meta.target_point.unwrap_or([0.0, 0.0, 0.0]);
+            Transform::from_translation(translation)
+                .looking_at(Vec3::new(target[0], target[1], target[2]), Vec3::Y)
+        };
 
         // Build object rotation (convert from f32 metadata to f64)
         let rot = render_meta.rotation_euler;
@@ -402,11 +434,16 @@ mod tests {
         // Create minimal metadata
         let metadata = DatasetMetadata {
             version: "1.0".to_string(),
+            crate_version: None,
+            renderer_policy_version: None,
             objects: vec!["test_object".to_string()],
             viewpoints_per_rotation: 24,
             rotations_per_object: 3,
             renders_per_object: 72,
             resolution: [64, 64],
+            resolution_width: None,
+            resolution_height: None,
+            targeting_policy: None,
             intrinsics: IntrinsicsMetadata {
                 focal_length: [55.4, 55.4],
                 principal_point: [32.0, 32.0],
@@ -478,11 +515,16 @@ mod tests {
     fn test_metadata_serialization_roundtrip() {
         let metadata = DatasetMetadata {
             version: "1.0".to_string(),
+            crate_version: Some("0.5.5".to_string()),
+            renderer_policy_version: Some(crate::RENDERER_POLICY_VERSION.to_string()),
             objects: vec!["obj1".to_string(), "obj2".to_string()],
             viewpoints_per_rotation: 24,
             rotations_per_object: 3,
             renders_per_object: 72,
             resolution: [64, 64],
+            resolution_width: Some(64),
+            resolution_height: Some(64),
+            targeting_policy: Some(TargetingPolicy::MeshCenter),
             intrinsics: IntrinsicsMetadata {
                 focal_length: [55.4, 55.4],
                 principal_point: [32.0, 32.0],
@@ -512,6 +554,21 @@ mod tests {
             viewpoint_index: 5,
             rotation_euler: [0.0, 90.0, 0.0],
             camera_position: [0.5, 0.0, 0.0],
+            camera_rotation_xyzw: Some([0.0, 0.0, 0.0, 1.0]),
+            target_point: Some([0.0, 0.0, 0.0]),
+            targeting_policy: Some(TargetingPolicy::Origin),
+            mesh_bounds: None,
+            health: Some(RenderHealth {
+                center_pixel: Some([32, 32]),
+                center_depth: Some(0.25),
+                center_foreground: true,
+                foreground_pixel_count: 1,
+                foreground_coverage: 1.0 / 4096.0,
+                center_5x5_foreground_count: 1,
+                nearest_foreground_pixel: Some([32, 32]),
+                nearest_foreground_depth: Some(0.25),
+                nearest_foreground_distance_px: Some(0.0),
+            }),
             rgba_file: "r1_v05.png".to_string(),
             depth_file: "r1_v05.depth".to_string(),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,8 +51,9 @@
 //! ```
 
 use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
 use std::f32::consts::PI;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 // Headless rendering implementation
 // Full GPU rendering requires a display - see render module for details
@@ -70,10 +71,13 @@ pub mod cache;
 // Test fixtures for pre-rendered images (CI/CD support)
 pub mod fixtures;
 
+/// Stable renderer/targeting-policy version for cache manifests.
+pub const RENDERER_POLICY_VERSION: &str = "tbp-targeting-v1";
+
 // Re-export ycbust types for convenience
 pub use ycbust::{
-    self, DownloadOptions, Subset as YcbSubset, REPRESENTATIVE_OBJECTS, TBP_SIMILAR_OBJECTS,
-    TBP_STANDARD_OBJECTS,
+    self, DownloadOptions, Subset as YcbSubset, GOOGLE_16K_MESH_RELATIVE, REPRESENTATIVE_OBJECTS,
+    TBP_SIMILAR_OBJECTS, TBP_STANDARD_OBJECTS,
 };
 
 /// YCB dataset utilities
@@ -325,6 +329,62 @@ impl ViewpointConfig {
     }
 }
 
+/// Axis-aligned mesh bounds in object-local coordinates.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct MeshBounds {
+    /// Minimum object-local vertex coordinate.
+    pub min: Vec3,
+    /// Maximum object-local vertex coordinate.
+    pub max: Vec3,
+    /// Center of the axis-aligned bounding box.
+    pub center: Vec3,
+    /// Number of vertices inspected while computing the bounds.
+    pub vertex_count: usize,
+}
+
+impl MeshBounds {
+    /// Size of the axis-aligned bounding box on each axis.
+    pub fn extents(&self) -> Vec3 {
+        self.max - self.min
+    }
+}
+
+/// Render-target selection policy for TBP/YCB camera orbits.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "policy", content = "target", rename_all = "snake_case")]
+pub enum TargetingPolicy {
+    /// Preserve historical behavior: camera viewpoints look at world origin.
+    Origin,
+    /// Load the YCB mesh AABB center and rotate it by the object rotation.
+    MeshCenter,
+    /// Use a caller-provided world target point.
+    ExplicitTarget([f32; 3]),
+}
+
+impl TargetingPolicy {
+    /// Stable label for manifests and logs.
+    pub fn label(&self) -> &'static str {
+        match self {
+            TargetingPolicy::Origin => "origin",
+            TargetingPolicy::MeshCenter => "mesh-center",
+            TargetingPolicy::ExplicitTarget(_) => "explicit-target",
+        }
+    }
+}
+
+/// Generated viewpoints plus the target metadata used to create them.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TargetedViewpoints {
+    /// Targeting policy used for this viewpoint set.
+    pub policy: TargetingPolicy,
+    /// Point every viewpoint looks at in world coordinates.
+    pub target_point: Vec3,
+    /// Mesh bounds when the policy required loading object-local bounds.
+    pub mesh_bounds: Option<MeshBounds>,
+    /// Camera viewpoints for the selected policy.
+    pub viewpoints: Vec<Transform>,
+}
+
 /// Full sensor configuration for capture sessions
 #[derive(Clone, Debug, Resource)]
 pub struct SensorConfig {
@@ -383,6 +443,16 @@ impl SensorConfig {
 /// - Pitch: elevation angle from horizontal plane (-90° to +90°)
 /// - Radius: distance from origin (object center)
 pub fn generate_viewpoints(config: &ViewpointConfig) -> Vec<Transform> {
+    generate_viewpoints_around_target(config, Vec3::ZERO)
+}
+
+/// Generate camera viewpoints around an explicit target point.
+///
+/// The generated camera offsets match [`generate_viewpoints`], but each camera
+/// is translated by `target` and rotated to look at that target. This is the
+/// caller-provided target form used by NeoCortx parity probes that should not
+/// assume the object surface of interest is at the world origin.
+pub fn generate_viewpoints_around_target(config: &ViewpointConfig, target: Vec3) -> Vec<Transform> {
     let mut views = Vec::with_capacity(config.viewpoint_count());
 
     for pitch_deg in &config.pitch_angles_deg {
@@ -399,11 +469,144 @@ pub fn generate_viewpoints(config: &ViewpointConfig) -> Vec<Transform> {
             let y = config.radius * pitch.sin();
             let z = config.radius * pitch.cos() * yaw.cos();
 
-            let transform = Transform::from_xyz(x, y, z).looking_at(Vec3::ZERO, Vec3::Y);
+            let translation = target + Vec3::new(x, y, z);
+            let transform = Transform::from_translation(translation).looking_at(target, Vec3::Y);
             views.push(transform);
         }
     }
     views
+}
+
+/// Rotate an object-local mesh center into the rendered world frame.
+///
+/// This uses the same object-rotation convention as rendering itself
+/// (`ObjectRotation::to_quat`). It intentionally applies yaw-only rotations as
+/// well as pitch/roll rotations, so downstream parity code does not need a
+/// temporary special case for centered YCB renders.
+pub fn rotated_mesh_center(mesh_center: Vec3, object_rotation: &ObjectRotation) -> Vec3 {
+    object_rotation.to_quat() * mesh_center
+}
+
+/// Generate TBP viewpoint transforms around a rotated object mesh center.
+///
+/// Use this when the YCB mesh's AABB center is a better render target than the
+/// source origin. The camera orbit remains exactly the same shape as
+/// [`generate_viewpoints`], but centered on `object_rotation * mesh_center`.
+pub fn generate_object_centered_viewpoints(
+    config: &ViewpointConfig,
+    mesh_center: Vec3,
+    object_rotation: &ObjectRotation,
+) -> Vec<Transform> {
+    generate_viewpoints_around_target(config, rotated_mesh_center(mesh_center, object_rotation))
+}
+
+/// Load axis-aligned bounds from an OBJ mesh.
+///
+/// This is a small public wrapper around the same YCB `google_16k/textured.obj`
+/// layout used by the renderer. It lets downstream callers avoid carrying their
+/// own OBJ parsing just to target an object's visual center.
+pub fn load_mesh_bounds(mesh_path: &Path) -> Result<MeshBounds, RenderError> {
+    if !mesh_path.exists() {
+        return Err(RenderError::MeshNotFound(mesh_path.display().to_string()));
+    }
+
+    let (models, _) = tobj::load_obj(
+        mesh_path,
+        &tobj::LoadOptions {
+            triangulate: false,
+            single_index: true,
+            ..Default::default()
+        },
+    )
+    .map_err(|err| {
+        RenderError::DataParsingError(format!(
+            "Failed to parse OBJ mesh {}: {}",
+            mesh_path.display(),
+            err
+        ))
+    })?;
+
+    let mut min = Vec3::splat(f32::INFINITY);
+    let mut max = Vec3::splat(f32::NEG_INFINITY);
+    let mut vertex_count = 0usize;
+
+    for model in models {
+        for vertex in model.mesh.positions.chunks_exact(3) {
+            let point = Vec3::new(vertex[0], vertex[1], vertex[2]);
+            min = min.min(point);
+            max = max.max(point);
+            vertex_count += 1;
+        }
+    }
+
+    if vertex_count == 0 {
+        return Err(RenderError::DataParsingError(format!(
+            "OBJ mesh {} contains no vertices",
+            mesh_path.display()
+        )));
+    }
+
+    Ok(MeshBounds {
+        min,
+        max,
+        center: (min + max) * 0.5,
+        vertex_count,
+    })
+}
+
+/// Load bounds for a YCB object directory using the standard google_16k mesh.
+pub fn load_ycb_mesh_bounds(object_dir: &Path) -> Result<MeshBounds, RenderError> {
+    load_mesh_bounds(&object_dir.join(GOOGLE_16K_MESH_RELATIVE))
+}
+
+/// Generate object-centered TBP viewpoints for a YCB object directory.
+pub fn generate_ycb_object_centered_viewpoints(
+    object_dir: &Path,
+    config: &ViewpointConfig,
+    object_rotation: &ObjectRotation,
+) -> Result<Vec<Transform>, RenderError> {
+    let bounds = load_ycb_mesh_bounds(object_dir)?;
+    Ok(generate_object_centered_viewpoints(
+        config,
+        bounds.center,
+        object_rotation,
+    ))
+}
+
+/// Generate viewpoints for a requested targeting policy.
+pub fn generate_targeted_viewpoints(
+    object_dir: &Path,
+    config: &ViewpointConfig,
+    object_rotation: &ObjectRotation,
+    policy: &TargetingPolicy,
+) -> Result<TargetedViewpoints, RenderError> {
+    match policy {
+        TargetingPolicy::Origin => Ok(TargetedViewpoints {
+            policy: policy.clone(),
+            target_point: Vec3::ZERO,
+            mesh_bounds: None,
+            viewpoints: generate_viewpoints(config),
+        }),
+        TargetingPolicy::MeshCenter => {
+            let bounds = load_ycb_mesh_bounds(object_dir)?;
+            let target_point = rotated_mesh_center(bounds.center, object_rotation);
+            Ok(TargetedViewpoints {
+                policy: policy.clone(),
+                target_point,
+                mesh_bounds: Some(bounds),
+                viewpoints: generate_viewpoints_around_target(config, target_point),
+            })
+        }
+        TargetingPolicy::ExplicitTarget(target) => {
+            let target_point = Vec3::from_array(*target);
+            Ok(TargetedViewpoints {
+                policy: policy.clone(),
+                target_point,
+                mesh_bounds: None,
+                viewpoints: generate_viewpoints_around_target(config, target_point),
+            })
+        }
+    }
 }
 
 /// Marker component for the target object being captured
@@ -633,6 +836,29 @@ impl CameraIntrinsics {
     }
 }
 
+/// Cheap diagnostics derived from a rendered depth buffer.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct RenderHealth {
+    /// Center pixel selected from camera intrinsics, clamped to image bounds.
+    pub center_pixel: Option<[u32; 2]>,
+    /// Raw depth at the center pixel, including far-plane/background values.
+    pub center_depth: Option<f64>,
+    /// Whether the center pixel has a finite positive depth before the far plane.
+    pub center_foreground: bool,
+    /// Number of foreground pixels in the full depth buffer.
+    pub foreground_pixel_count: usize,
+    /// Foreground fraction in `[0, 1]` over the declared image size.
+    pub foreground_coverage: f64,
+    /// Number of foreground pixels in the 5x5 window centered on `center_pixel`.
+    pub center_5x5_foreground_count: usize,
+    /// Foreground pixel nearest to `center_pixel`, if any foreground exists.
+    pub nearest_foreground_pixel: Option<[u32; 2]>,
+    /// Depth at `nearest_foreground_pixel`.
+    pub nearest_foreground_depth: Option<f64>,
+    /// Euclidean pixel distance from `center_pixel` to `nearest_foreground_pixel`.
+    pub nearest_foreground_distance_px: Option<f64>,
+}
+
 /// Output from headless rendering containing RGBA and depth data.
 #[derive(Clone, Debug)]
 pub struct RenderOutput {
@@ -655,6 +881,9 @@ pub struct RenderOutput {
 }
 
 impl RenderOutput {
+    /// Default far plane used by TBP render helpers.
+    pub const TBP_FAR_PLANE_METERS: f64 = 10.0;
+
     /// Get RGBA pixel at (x, y). Returns None if out of bounds.
     pub fn get_rgba(&self, x: u32, y: u32) -> Option<[u8; 4]> {
         if x >= self.width || y >= self.height {
@@ -681,6 +910,191 @@ impl RenderOutput {
     /// Get RGB pixel (without alpha) at (x, y).
     pub fn get_rgb(&self, x: u32, y: u32) -> Option<[u8; 3]> {
         self.get_rgba(x, y).map(|rgba| [rgba[0], rgba[1], rgba[2]])
+    }
+
+    /// Pixel nearest the camera principal point, clamped to image bounds.
+    pub fn center_pixel(&self) -> Option<[u32; 2]> {
+        if self.width == 0 || self.height == 0 {
+            return None;
+        }
+
+        let x = self.intrinsics.principal_point[0]
+            .round()
+            .clamp(0.0, (self.width - 1) as f64) as u32;
+        let y = self.intrinsics.principal_point[1]
+            .round()
+            .clamp(0.0, (self.height - 1) as f64) as u32;
+        Some([x, y])
+    }
+
+    /// Raw center-pixel depth, including far-plane/background values.
+    pub fn center_pixel_raw_depth(&self) -> Option<f64> {
+        let [x, y] = self.center_pixel()?;
+        self.get_depth(x, y)
+    }
+
+    /// Center-pixel object depth using the TBP default far plane.
+    pub fn center_pixel_depth(&self) -> Option<f64> {
+        self.center_pixel_depth_with_far_plane(Self::TBP_FAR_PLANE_METERS)
+    }
+
+    /// Center-pixel object depth using a caller-provided far plane.
+    pub fn center_pixel_depth_with_far_plane(&self, far_plane: f64) -> Option<f64> {
+        self.center_pixel_raw_depth()
+            .filter(|depth| Self::is_foreground_depth(*depth, far_plane))
+    }
+
+    /// Whether a depth value should be treated as foreground/object surface.
+    pub fn is_foreground_depth(depth: f64, far_plane: f64) -> bool {
+        depth.is_finite() && depth > 0.0 && far_plane.is_finite() && depth < far_plane * 0.999
+    }
+
+    /// Compute render-health diagnostics using the TBP default far plane.
+    pub fn health(&self) -> RenderHealth {
+        self.health_with_far_plane(Self::TBP_FAR_PLANE_METERS)
+    }
+
+    /// Compute render-health diagnostics using a caller-provided far plane.
+    pub fn health_with_far_plane(&self, far_plane: f64) -> RenderHealth {
+        let center_pixel = self.center_pixel();
+        let center_depth = self.center_pixel_raw_depth();
+        let center_foreground = center_depth
+            .map(|depth| Self::is_foreground_depth(depth, far_plane))
+            .unwrap_or(false);
+
+        let total_pixels = (self.width as usize).saturating_mul(self.height as usize);
+        let mut foreground_pixel_count = 0usize;
+        let mut center_5x5_foreground_count = 0usize;
+        let mut nearest_foreground_pixel = None;
+        let mut nearest_foreground_depth = None;
+        let mut nearest_foreground_distance_px = None;
+
+        for y in 0..self.height {
+            for x in 0..self.width {
+                let Some(depth) = self.get_depth(x, y) else {
+                    continue;
+                };
+                if !Self::is_foreground_depth(depth, far_plane) {
+                    continue;
+                }
+
+                foreground_pixel_count += 1;
+
+                if let Some([cx, cy]) = center_pixel {
+                    let dx = x as i64 - cx as i64;
+                    let dy = y as i64 - cy as i64;
+
+                    if dx.abs() <= 2 && dy.abs() <= 2 {
+                        center_5x5_foreground_count += 1;
+                    }
+
+                    let distance = ((dx * dx + dy * dy) as f64).sqrt();
+                    if nearest_foreground_distance_px
+                        .map(|current| distance < current)
+                        .unwrap_or(true)
+                    {
+                        nearest_foreground_pixel = Some([x, y]);
+                        nearest_foreground_depth = Some(depth);
+                        nearest_foreground_distance_px = Some(distance);
+                    }
+                }
+            }
+        }
+
+        RenderHealth {
+            center_pixel,
+            center_depth,
+            center_foreground,
+            foreground_pixel_count,
+            foreground_coverage: if total_pixels > 0 {
+                foreground_pixel_count as f64 / total_pixels as f64
+            } else {
+                0.0
+            },
+            center_5x5_foreground_count,
+            nearest_foreground_pixel,
+            nearest_foreground_depth,
+            nearest_foreground_distance_px,
+        }
+    }
+
+    /// Transform a point from Bevy camera-local coordinates into world space.
+    pub fn camera_to_world_point(&self, camera_point: [f64; 3]) -> [f64; 3] {
+        let point = Vec3::new(
+            camera_point[0] as f32,
+            camera_point[1] as f32,
+            camera_point[2] as f32,
+        );
+        let rotated = self.camera_transform.rotation * point;
+        let translated = self.camera_transform.translation + rotated;
+        [
+            translated.x as f64,
+            translated.y as f64,
+            translated.z as f64,
+        ]
+    }
+
+    /// Transform a point from world space into Bevy camera-local coordinates.
+    pub fn world_to_camera_point(&self, world_point: [f64; 3]) -> [f64; 3] {
+        let point = Vec3::new(
+            world_point[0] as f32,
+            world_point[1] as f32,
+            world_point[2] as f32,
+        );
+        let relative = point - self.camera_transform.translation;
+        let camera_point = self.camera_transform.rotation.inverse() * relative;
+        [
+            camera_point.x as f64,
+            camera_point.y as f64,
+            camera_point.z as f64,
+        ]
+    }
+
+    /// Surface point at the center pixel using the TBP default far plane.
+    pub fn center_surface_point_world(&self) -> Option<[f64; 3]> {
+        self.center_surface_point_world_with_far_plane(Self::TBP_FAR_PLANE_METERS)
+    }
+
+    /// Surface point at the center pixel using a caller-provided far plane.
+    pub fn center_surface_point_world_with_far_plane(&self, far_plane: f64) -> Option<[f64; 3]> {
+        let [x, y] = self.center_pixel()?;
+        self.pixel_surface_point_world_with_far_plane([x, y], far_plane)
+    }
+
+    /// Surface point at `pixel` using the TBP default far plane.
+    pub fn pixel_surface_point_world(&self, pixel: [u32; 2]) -> Option<[f64; 3]> {
+        self.pixel_surface_point_world_with_far_plane(pixel, Self::TBP_FAR_PLANE_METERS)
+    }
+
+    /// Surface point at `pixel` using a caller-provided far plane.
+    ///
+    /// Pixel coordinates follow image convention (`x` right, `y` down). The
+    /// returned point is in world space. Internally this maps to Bevy's camera
+    /// frame (`+X` right, `+Y` up, `-Z` forward).
+    pub fn pixel_surface_point_world_with_far_plane(
+        &self,
+        pixel: [u32; 2],
+        far_plane: f64,
+    ) -> Option<[f64; 3]> {
+        let [x, y] = pixel;
+        let depth = self.get_depth(x, y)?;
+        if !Self::is_foreground_depth(depth, far_plane) {
+            return None;
+        }
+
+        let fx = self.intrinsics.focal_length[0];
+        let fy = self.intrinsics.focal_length[1];
+        if !fx.is_finite()
+            || !fy.is_finite()
+            || fx.abs() <= f64::EPSILON
+            || fy.abs() <= f64::EPSILON
+        {
+            return None;
+        }
+
+        let camera_x = (x as f64 - self.intrinsics.principal_point[0]) / fx * depth;
+        let camera_y = -((y as f64 - self.intrinsics.principal_point[1]) / fy * depth);
+        Some(self.camera_to_world_point([camera_x, camera_y, -depth]))
     }
 
     /// Convert to neocortx-compatible image format: Vec<Vec<[u8; 3]>>
@@ -828,6 +1242,153 @@ pub fn render_all_viewpoints(
     }
 
     Ok(outputs)
+}
+
+/// Structured center-hit validation report for one object.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CenterHitValidationReport {
+    /// Object identifier used in logs/manifests.
+    pub object_id: String,
+    /// Object directory rendered.
+    pub object_dir: String,
+    /// Targeting policy used for all rotations.
+    pub target_policy: TargetingPolicy,
+    /// Per-rotation center-hit results.
+    pub rotations: Vec<CenterHitRotationReport>,
+}
+
+impl CenterHitValidationReport {
+    /// True when every rotation has at least one center-foreground hit.
+    pub fn is_valid(&self) -> bool {
+        self.rotations
+            .iter()
+            .all(|rotation| rotation.center_hits > 0)
+    }
+
+    /// Rotation indices with zero center-foreground hits.
+    pub fn zero_hit_rotations(&self) -> Vec<usize> {
+        self.rotations
+            .iter()
+            .filter(|rotation| rotation.center_hits == 0)
+            .map(|rotation| rotation.rotation_index)
+            .collect()
+    }
+}
+
+/// Center-hit validation result for a single object rotation.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CenterHitRotationReport {
+    pub rotation_index: usize,
+    pub rotation_euler: [f64; 3],
+    pub target_point: [f32; 3],
+    pub mesh_bounds: Option<MeshBoundsMetadata>,
+    pub total_viewpoints: usize,
+    pub center_hits: usize,
+    pub center_misses: usize,
+    pub misses: Vec<CenterHitMiss>,
+}
+
+/// Serializable mesh-bounds metadata for reports and manifests.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct MeshBoundsMetadata {
+    pub min: [f32; 3],
+    pub max: [f32; 3],
+    pub center: [f32; 3],
+    pub vertex_count: usize,
+}
+
+impl From<MeshBounds> for MeshBoundsMetadata {
+    fn from(bounds: MeshBounds) -> Self {
+        Self {
+            min: bounds.min.to_array(),
+            max: bounds.max.to_array(),
+            center: bounds.center.to_array(),
+            vertex_count: bounds.vertex_count,
+        }
+    }
+}
+
+/// Center-hit miss with enough metadata to reproduce the bad viewpoint.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CenterHitMiss {
+    pub viewpoint_index: usize,
+    pub camera_position: [f32; 3],
+    pub camera_rotation_xyzw: [f32; 4],
+    pub health: RenderHealth,
+}
+
+/// Validate that each rotation has at least one viewpoint whose center pixel
+/// lands on foreground before the render far plane.
+pub fn validate_center_hits(
+    object_id: impl Into<String>,
+    object_dir: &Path,
+    viewpoint_config: &ViewpointConfig,
+    rotations: &[ObjectRotation],
+    render_config: &RenderConfig,
+    target_policy: &TargetingPolicy,
+) -> Result<CenterHitValidationReport, RenderError> {
+    let object_id = object_id.into();
+    let mut rotation_reports = Vec::with_capacity(rotations.len());
+
+    for (rotation_index, rotation) in rotations.iter().enumerate() {
+        let targeted =
+            generate_targeted_viewpoints(object_dir, viewpoint_config, rotation, target_policy)?;
+        let requests: Vec<batch::BatchRenderRequest> = targeted
+            .viewpoints
+            .iter()
+            .map(|viewpoint| batch::BatchRenderRequest {
+                object_dir: PathBuf::from(object_dir),
+                viewpoint: *viewpoint,
+                object_rotation: rotation.clone(),
+                render_config: render_config.clone(),
+            })
+            .collect();
+
+        let outputs = render_batch(requests, &batch::BatchRenderConfig::default())
+            .map_err(|error| RenderError::RenderFailed(error.to_string()))?;
+
+        let mut center_hits = 0usize;
+        let mut misses = Vec::new();
+        for (viewpoint_index, output) in outputs.iter().enumerate() {
+            if output.status != batch::RenderStatus::Success {
+                return Err(RenderError::RenderFailed(format!(
+                    "Render failed for {} rotation {} viewpoint {}: {:?}",
+                    object_id, rotation_index, viewpoint_index, output.error_message
+                )));
+            }
+
+            if output.health.center_foreground {
+                center_hits += 1;
+            } else {
+                let t = output.request.viewpoint.translation;
+                let q = output.request.viewpoint.rotation;
+                misses.push(CenterHitMiss {
+                    viewpoint_index,
+                    camera_position: [t.x, t.y, t.z],
+                    camera_rotation_xyzw: [q.x, q.y, q.z, q.w],
+                    health: output.health.clone(),
+                });
+            }
+        }
+
+        rotation_reports.push(CenterHitRotationReport {
+            rotation_index,
+            rotation_euler: [rotation.pitch, rotation.yaw, rotation.roll],
+            target_point: targeted.target_point.to_array(),
+            mesh_bounds: targeted.mesh_bounds.map(MeshBoundsMetadata::from),
+            total_viewpoints: outputs.len(),
+            center_hits,
+            center_misses: outputs.len().saturating_sub(center_hits),
+            misses,
+        });
+    }
+
+    Ok(CenterHitValidationReport {
+        object_id,
+        object_dir: object_dir.display().to_string(),
+        target_policy: target_policy.clone(),
+        rotations: rotation_reports,
+    })
 }
 
 /// Render with model caching support for efficient multi-viewpoint rendering.
@@ -1141,6 +1702,45 @@ pub use bevy::prelude::{Quat, Transform, Vec3};
 mod tests {
     use super::*;
 
+    fn assert_vec3_close(actual: Vec3, expected: Vec3) {
+        assert!(
+            (actual - expected).length() < 1e-5,
+            "expected {:?}, got {:?}",
+            expected,
+            actual
+        );
+    }
+
+    fn assert_point_close(actual: [f64; 3], expected: [f64; 3]) {
+        for axis in 0..3 {
+            assert!(
+                (actual[axis] - expected[axis]).abs() < 1e-5,
+                "axis {} expected {:?}, got {:?}",
+                axis,
+                expected,
+                actual
+            );
+        }
+    }
+
+    fn render_output_for_depth(
+        width: u32,
+        height: u32,
+        depth: Vec<f64>,
+        intrinsics: CameraIntrinsics,
+        camera_transform: Transform,
+    ) -> RenderOutput {
+        RenderOutput {
+            rgba: vec![0u8; (width * height * 4) as usize],
+            depth,
+            width,
+            height,
+            intrinsics,
+            camera_transform,
+            object_rotation: ObjectRotation::identity(),
+        }
+    }
+
     #[test]
     fn test_object_rotation_identity() {
         let rot = ObjectRotation::identity();
@@ -1284,6 +1884,141 @@ mod tests {
                 dot
             );
         }
+    }
+
+    #[test]
+    fn test_generate_viewpoints_around_target_preserves_orbit() {
+        let config = ViewpointConfig {
+            radius: 2.0,
+            yaw_count: 4,
+            pitch_angles_deg: vec![0.0],
+        };
+        let target = Vec3::new(1.0, -0.5, 0.25);
+        let viewpoints = generate_viewpoints_around_target(&config, target);
+
+        assert_eq!(viewpoints.len(), 4);
+        for (i, transform) in viewpoints.iter().enumerate() {
+            let offset = transform.translation - target;
+            assert!(
+                (offset.length() - config.radius).abs() < 1e-5,
+                "viewpoint {} has radius {}, expected {}",
+                i,
+                offset.length(),
+                config.radius
+            );
+
+            let forward = transform.forward();
+            let to_target = (target - transform.translation).normalize();
+            assert!(
+                forward.dot(to_target) > 0.99,
+                "viewpoint {} is not looking at target",
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn test_generate_viewpoints_keeps_origin_targeting() {
+        let config = ViewpointConfig {
+            radius: 1.0,
+            yaw_count: 1,
+            pitch_angles_deg: vec![0.0],
+        };
+
+        let origin_view = generate_viewpoints(&config)[0];
+        let explicit_origin_view = generate_viewpoints_around_target(&config, Vec3::ZERO)[0];
+
+        assert_vec3_close(origin_view.translation, explicit_origin_view.translation);
+        let forward = origin_view.forward();
+        let to_origin = (Vec3::ZERO - origin_view.translation).normalize();
+        assert!(forward.dot(to_origin) > 0.99);
+    }
+
+    #[test]
+    fn test_object_centered_viewpoints_apply_yaw_rotation_to_target() {
+        let config = ViewpointConfig {
+            radius: 1.0,
+            yaw_count: 1,
+            pitch_angles_deg: vec![0.0],
+        };
+        let mesh_center = Vec3::new(0.25, 0.0, 0.0);
+        let rotation = ObjectRotation::new(0.0, 90.0, 0.0);
+
+        let target = rotated_mesh_center(mesh_center, &rotation);
+        assert!(target.distance(mesh_center) > 0.1);
+
+        let origin_view = generate_viewpoints(&config)[0];
+        let centered_view = generate_object_centered_viewpoints(&config, mesh_center, &rotation)[0];
+
+        assert_vec3_close(centered_view.translation, origin_view.translation + target);
+        let forward = centered_view.forward();
+        let to_target = (target - centered_view.translation).normalize();
+        assert!(forward.dot(to_target) > 0.99);
+    }
+
+    #[test]
+    fn test_load_ycb_mesh_bounds_from_standard_obj_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let mesh_dir = dir.path().join("google_16k");
+        std::fs::create_dir_all(&mesh_dir).unwrap();
+        std::fs::write(
+            mesh_dir.join("textured.obj"),
+            "v -1.0 -2.0 -3.0\nv 3.0 4.0 5.0\nv 1.0 0.0 2.0\nf 1 2 3\n",
+        )
+        .unwrap();
+
+        let bounds = load_ycb_mesh_bounds(dir.path()).unwrap();
+
+        assert_eq!(bounds.vertex_count, 3);
+        assert_vec3_close(bounds.min, Vec3::new(-1.0, -2.0, -3.0));
+        assert_vec3_close(bounds.max, Vec3::new(3.0, 4.0, 5.0));
+        assert_vec3_close(bounds.center, Vec3::new(1.0, 1.0, 1.0));
+        assert_vec3_close(bounds.extents(), Vec3::new(4.0, 6.0, 8.0));
+    }
+
+    #[test]
+    fn test_targeting_policy_serializes_stable_label() {
+        assert_eq!(TargetingPolicy::Origin.label(), "origin");
+        assert_eq!(TargetingPolicy::MeshCenter.label(), "mesh-center");
+
+        let json = serde_json::to_string(&TargetingPolicy::MeshCenter).unwrap();
+        assert!(json.contains("mesh_center"));
+        let loaded: TargetingPolicy = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded, TargetingPolicy::MeshCenter);
+    }
+
+    #[test]
+    fn test_center_hit_validation_report_detects_zero_hit_rotation() {
+        let report = CenterHitValidationReport {
+            object_id: "test_object".to_string(),
+            object_dir: "/tmp/ycb/test_object".to_string(),
+            target_policy: TargetingPolicy::MeshCenter,
+            rotations: vec![
+                CenterHitRotationReport {
+                    rotation_index: 0,
+                    rotation_euler: [0.0, 0.0, 0.0],
+                    target_point: [0.0, 0.0, 0.0],
+                    mesh_bounds: None,
+                    total_viewpoints: 24,
+                    center_hits: 1,
+                    center_misses: 23,
+                    misses: Vec::new(),
+                },
+                CenterHitRotationReport {
+                    rotation_index: 1,
+                    rotation_euler: [0.0, 90.0, 0.0],
+                    target_point: [0.1, 0.0, 0.0],
+                    mesh_bounds: None,
+                    total_viewpoints: 24,
+                    center_hits: 0,
+                    center_misses: 24,
+                    misses: Vec::new(),
+                },
+            ],
+        };
+
+        assert!(!report.is_valid());
+        assert_eq!(report.zero_hit_rotations(), vec![1]);
     }
 
     #[test]
@@ -1571,6 +2306,135 @@ mod tests {
         assert_eq!(depth_image.len(), 2);
         assert_eq!(depth_image[0], vec![1.0, 2.0]);
         assert_eq!(depth_image[1], vec![3.0, 4.0]);
+    }
+
+    #[test]
+    fn test_render_health_center_hit() {
+        let mut depth = vec![10.0; 7 * 7];
+        depth[3 * 7 + 3] = 0.25;
+        depth[6 * 7 + 6] = 0.5;
+        let output = render_output_for_depth(
+            7,
+            7,
+            depth,
+            CameraIntrinsics {
+                focal_length: [10.0, 10.0],
+                principal_point: [3.0, 3.0],
+                image_size: [7, 7],
+            },
+            Transform::IDENTITY,
+        );
+
+        let health = output.health();
+
+        assert_eq!(health.center_pixel, Some([3, 3]));
+        assert_eq!(health.center_depth, Some(0.25));
+        assert!(health.center_foreground);
+        assert_eq!(health.foreground_pixel_count, 2);
+        assert!((health.foreground_coverage - 2.0 / 49.0).abs() < 1e-12);
+        assert_eq!(health.center_5x5_foreground_count, 1);
+        assert_eq!(health.nearest_foreground_pixel, Some([3, 3]));
+        assert_eq!(health.nearest_foreground_depth, Some(0.25));
+        assert_eq!(health.nearest_foreground_distance_px, Some(0.0));
+    }
+
+    #[test]
+    fn test_render_health_far_center_uses_nearest_foreground() {
+        let mut depth = vec![10.0; 7 * 7];
+        depth[3 * 7 + 1] = 0.5;
+        let output = render_output_for_depth(
+            7,
+            7,
+            depth,
+            CameraIntrinsics {
+                focal_length: [10.0, 10.0],
+                principal_point: [3.0, 3.0],
+                image_size: [7, 7],
+            },
+            Transform::IDENTITY,
+        );
+
+        let health = output.health();
+
+        assert_eq!(health.center_pixel, Some([3, 3]));
+        assert_eq!(health.center_depth, Some(10.0));
+        assert!(!health.center_foreground);
+        assert_eq!(health.foreground_pixel_count, 1);
+        assert_eq!(health.center_5x5_foreground_count, 1);
+        assert_eq!(health.nearest_foreground_pixel, Some([1, 3]));
+        assert_eq!(health.nearest_foreground_depth, Some(0.5));
+        assert_eq!(health.nearest_foreground_distance_px, Some(2.0));
+    }
+
+    #[test]
+    fn test_center_surface_point_world_uses_bevy_camera_forward() {
+        let mut depth = vec![10.0; 3 * 3];
+        depth[3 + 1] = 0.25;
+        let output = render_output_for_depth(
+            3,
+            3,
+            depth,
+            CameraIntrinsics {
+                focal_length: [1.0, 1.0],
+                principal_point: [1.0, 1.0],
+                image_size: [3, 3],
+            },
+            Transform::IDENTITY,
+        );
+
+        assert_eq!(output.center_pixel_depth(), Some(0.25));
+        assert_point_close(
+            output.center_surface_point_world().expect("surface point"),
+            [0.0, 0.0, -0.25],
+        );
+    }
+
+    #[test]
+    fn test_pixel_surface_point_world_maps_image_y_down_to_camera_y_up() {
+        let mut depth = vec![10.0; 3 * 3];
+        depth[2] = 2.0;
+        let output = render_output_for_depth(
+            3,
+            3,
+            depth,
+            CameraIntrinsics {
+                focal_length: [1.0, 1.0],
+                principal_point: [1.0, 1.0],
+                image_size: [3, 3],
+            },
+            Transform::IDENTITY,
+        );
+
+        assert_point_close(
+            output
+                .pixel_surface_point_world([2, 0])
+                .expect("surface point"),
+            [2.0, 2.0, -2.0],
+        );
+    }
+
+    #[test]
+    fn test_camera_world_point_helpers_roundtrip() {
+        let output = render_output_for_depth(
+            1,
+            1,
+            vec![0.25],
+            CameraIntrinsics {
+                focal_length: [1.0, 1.0],
+                principal_point: [0.0, 0.0],
+                image_size: [1, 1],
+            },
+            Transform::from_xyz(0.0, 0.0, 1.0).looking_at(Vec3::ZERO, Vec3::Y),
+        );
+
+        assert_point_close(
+            output.center_surface_point_world().expect("surface point"),
+            [0.0, 0.0, 0.75],
+        );
+
+        let world_point = [0.1, -0.2, 0.7];
+        let camera_point = output.world_to_camera_point(world_point);
+        assert_point_close(output.camera_to_world_point(camera_point), world_point);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -878,11 +878,22 @@ pub struct RenderOutput {
     pub camera_transform: Transform,
     /// Object rotation applied during render
     pub object_rotation: ObjectRotation,
+    /// Point the camera was intended to target for this render.
+    pub target_point: Vec3,
+    /// Policy used to derive `target_point`.
+    pub targeting_policy: TargetingPolicy,
 }
 
 impl RenderOutput {
     /// Default far plane used by TBP render helpers.
     pub const TBP_FAR_PLANE_METERS: f64 = 10.0;
+
+    /// Attach the render target metadata used to generate this camera transform.
+    pub fn with_targeting(mut self, target_point: Vec3, targeting_policy: TargetingPolicy) -> Self {
+        self.target_point = target_point;
+        self.targeting_policy = targeting_policy;
+        self
+    }
 
     /// Get RGBA pixel at (x, y). Returns None if out of bounds.
     pub fn get_rgba(&self, x: u32, y: u32) -> Option<[u8; 4]> {
@@ -1213,6 +1224,23 @@ pub fn render_to_buffer(
     render::render_headless(object_dir, camera_transform, object_rotation, config)
 }
 
+/// Render a YCB object and attach the target metadata used for the camera pose.
+///
+/// This is useful when callers generate camera transforms with
+/// [`generate_targeted_viewpoints`] and need the live render output to carry the
+/// exact per-render pivot point for downstream pose compensation.
+pub fn render_to_buffer_with_target(
+    object_dir: &Path,
+    camera_transform: &Transform,
+    object_rotation: &ObjectRotation,
+    config: &RenderConfig,
+    target_point: Vec3,
+    targeting_policy: TargetingPolicy,
+) -> Result<RenderOutput, RenderError> {
+    render_to_buffer(object_dir, camera_transform, object_rotation, config)
+        .map(|output| output.with_targeting(target_point, targeting_policy))
+}
+
 /// Render all viewpoints and rotations for a YCB object.
 ///
 /// Convenience function that renders all combinations of viewpoints and rotations.
@@ -1341,6 +1369,8 @@ pub fn validate_center_hits(
                 viewpoint: *viewpoint,
                 object_rotation: rotation.clone(),
                 render_config: render_config.clone(),
+                target_point: targeted.target_point,
+                targeting_policy: target_policy.clone(),
             })
             .collect();
 
@@ -1447,7 +1477,10 @@ pub fn validate_center_hits(
 /// Bevy renderer across calls.
 ///
 /// ```ignore
-/// use bevy_sensor::{render_batch, batch::BatchRenderRequest, BatchRenderConfig, RenderConfig, ObjectRotation};
+/// use bevy_sensor::{
+///     render_batch, batch::BatchRenderRequest, BatchRenderConfig, RenderConfig,
+///     ObjectRotation, TargetingPolicy, Vec3,
+/// };
 ///
 /// let requests: Vec<_> = viewpoints.iter().map(|vp| {
 ///     BatchRenderRequest {
@@ -1455,6 +1488,8 @@ pub fn validate_center_hits(
 ///         viewpoint: *vp,
 ///         object_rotation: ObjectRotation::identity(),
 ///         render_config: RenderConfig::tbp_default(),
+///         target_point: Vec3::ZERO,
+///         targeting_policy: TargetingPolicy::Origin,
 ///     }
 /// }).collect();
 ///
@@ -1564,7 +1599,7 @@ pub fn create_batch_renderer(config: &BatchRenderConfig) -> Result<BatchRenderer
 ///
 /// # Example
 /// ```ignore
-/// use bevy_sensor::{batch::BatchRenderRequest, RenderConfig, ObjectRotation};
+/// use bevy_sensor::{batch::BatchRenderRequest, RenderConfig, ObjectRotation, TargetingPolicy, Vec3};
 /// use std::path::PathBuf;
 ///
 /// queue_render_request(&mut renderer, BatchRenderRequest {
@@ -1572,6 +1607,8 @@ pub fn create_batch_renderer(config: &BatchRenderConfig) -> Result<BatchRenderer
 ///     viewpoint: camera_transform,
 ///     object_rotation: ObjectRotation::identity(),
 ///     render_config: RenderConfig::tbp_default(),
+///     target_point: Vec3::ZERO,
+///     targeting_policy: TargetingPolicy::Origin,
 /// })?;
 /// ```
 pub fn queue_render_request(
@@ -1738,6 +1775,8 @@ mod tests {
             intrinsics,
             camera_transform,
             object_rotation: ObjectRotation::identity(),
+            target_point: Vec3::ZERO,
+            targeting_policy: TargetingPolicy::Origin,
         }
     }
 
@@ -1765,6 +1804,8 @@ mod tests {
             viewpoint: Transform::IDENTITY,
             object_rotation: ObjectRotation::identity(),
             render_config: config.clone(),
+            target_point: Vec3::ZERO,
+            targeting_policy: TargetingPolicy::Origin,
         };
 
         assert!(requests_share_batch_context(&[
@@ -1784,6 +1825,8 @@ mod tests {
             viewpoint: Transform::IDENTITY,
             object_rotation: ObjectRotation::identity(),
             render_config: config.clone(),
+            target_point: Vec3::ZERO,
+            targeting_policy: TargetingPolicy::Origin,
         };
 
         assert!(!requests_share_batch_context(&[
@@ -1985,6 +2028,22 @@ mod tests {
         assert!(json.contains("mesh_center"));
         let loaded: TargetingPolicy = serde_json::from_str(&json).unwrap();
         assert_eq!(loaded, TargetingPolicy::MeshCenter);
+    }
+
+    #[test]
+    fn test_render_output_with_targeting_overrides_origin_default() {
+        let target_point = Vec3::new(0.1, 0.2, -0.3);
+        let output = render_output_for_depth(
+            1,
+            1,
+            vec![1.0],
+            RenderConfig::tbp_default().intrinsics(),
+            Transform::IDENTITY,
+        )
+        .with_targeting(target_point, TargetingPolicy::MeshCenter);
+
+        assert_eq!(output.target_point, target_point);
+        assert_eq!(output.targeting_policy, TargetingPolicy::MeshCenter);
     }
 
     #[test]
@@ -2234,6 +2293,8 @@ mod tests {
             intrinsics: RenderConfig::tbp_default().intrinsics(),
             camera_transform: Transform::IDENTITY,
             object_rotation: ObjectRotation::identity(),
+            target_point: Vec3::ZERO,
+            targeting_policy: TargetingPolicy::Origin,
         };
 
         // Top-left: red
@@ -2258,6 +2319,8 @@ mod tests {
             intrinsics: RenderConfig::tbp_default().intrinsics(),
             camera_transform: Transform::IDENTITY,
             object_rotation: ObjectRotation::identity(),
+            target_point: Vec3::ZERO,
+            targeting_policy: TargetingPolicy::Origin,
         };
 
         assert_eq!(output.get_depth(0, 0), Some(1.0));
@@ -2279,6 +2342,8 @@ mod tests {
             intrinsics: RenderConfig::tbp_default().intrinsics(),
             camera_transform: Transform::IDENTITY,
             object_rotation: ObjectRotation::identity(),
+            target_point: Vec3::ZERO,
+            targeting_policy: TargetingPolicy::Origin,
         };
 
         let image = output.to_rgb_image();
@@ -2300,6 +2365,8 @@ mod tests {
             intrinsics: RenderConfig::tbp_default().intrinsics(),
             camera_transform: Transform::IDENTITY,
             object_rotation: ObjectRotation::identity(),
+            target_point: Vec3::ZERO,
+            targeting_policy: TargetingPolicy::Origin,
         };
 
         let depth_image = output.to_depth_image();
@@ -2551,6 +2618,8 @@ mod tests {
             intrinsics: RenderConfig::tbp_default().intrinsics(),
             camera_transform: Transform::IDENTITY,
             object_rotation: ObjectRotation::identity(),
+            target_point: Vec3::ZERO,
+            targeting_policy: TargetingPolicy::Origin,
         };
 
         // Should handle empty gracefully
@@ -2570,6 +2639,8 @@ mod tests {
             intrinsics: RenderConfig::tbp_default().intrinsics(),
             camera_transform: Transform::IDENTITY,
             object_rotation: ObjectRotation::identity(),
+            target_point: Vec3::ZERO,
+            targeting_policy: TargetingPolicy::Origin,
         };
 
         assert_eq!(output.get_rgba(0, 0), Some([128, 64, 32, 255]));

--- a/src/render.rs
+++ b/src/render.rs
@@ -70,7 +70,10 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
-use crate::{backend::BackendConfig, ObjectRotation, RenderConfig, RenderError, RenderOutput};
+use crate::{
+    backend::BackendConfig, ObjectRotation, RenderConfig, RenderError, RenderOutput,
+    TargetingPolicy,
+};
 use ycbust::{GOOGLE_16K_MESH_RELATIVE, GOOGLE_16K_TEXTURE_RELATIVE};
 
 /// Watchdog timeout for a single render, in seconds.
@@ -1553,6 +1556,8 @@ fn read_output_from_file(path: &std::path::Path) -> Result<RenderOutput, RenderE
             scale: Vec3::ONE,
         },
         object_rotation: ObjectRotation { pitch, yaw, roll },
+        target_point: Vec3::ZERO,
+        targeting_policy: TargetingPolicy::Origin,
     })
 }
 
@@ -1896,6 +1901,8 @@ fn extract_and_exit(
             intrinsics,
             camera_transform: request.camera_transform,
             object_rotation: request.object_rotation.clone(),
+            target_point: Vec3::ZERO,
+            targeting_policy: TargetingPolicy::Origin,
         };
 
         if let Ok(mut guard) = shared_output.0.lock() {
@@ -2223,6 +2230,8 @@ fn extract_and_exit_headless(
             intrinsics,
             camera_transform: request.camera_transform,
             object_rotation: request.object_rotation.clone(),
+            target_point: Vec3::ZERO,
+            targeting_policy: TargetingPolicy::Origin,
         };
 
         if let Ok(mut guard) = shared_output.0.lock() {
@@ -2300,6 +2309,8 @@ fn extract_and_continue_headless_batch(
                 .current_viewpoint()
                 .unwrap_or(request.camera_transform),
             object_rotation: request.object_rotation.clone(),
+            target_point: Vec3::ZERO,
+            targeting_policy: TargetingPolicy::Origin,
         };
         batch.outputs.push(output);
 
@@ -3210,7 +3221,8 @@ fn save_depth_to_binary(depth: &[f64], path: &Path) -> Result<(), String> {
 mod smoke_tests {
     use super::{headless_scene_setup_count, reset_headless_scene_setup_count};
     use crate::{
-        BatchRenderConfig, BatchRenderRequest, ObjectRotation, RenderConfig, ViewpointConfig,
+        BatchRenderConfig, BatchRenderRequest, ObjectRotation, RenderConfig, TargetingPolicy, Vec3,
+        ViewpointConfig,
     };
     use image::{ImageBuffer, Rgba};
     use tempfile::TempDir;
@@ -3284,6 +3296,8 @@ f 5/1 2/3 1/4
                 viewpoint,
                 object_rotation: ObjectRotation::identity(),
                 render_config: config.clone(),
+                target_point: Vec3::ZERO,
+                targeting_policy: TargetingPolicy::Origin,
             })
             .collect();
 

--- a/tests/render_integration.rs
+++ b/tests/render_integration.rs
@@ -19,7 +19,8 @@
 use bevy_sensor::{
     backend::detect_platform, batch::BatchRenderRequest, cache::ModelCache, render_batch,
     render_to_buffer, render_to_buffer_cached, BatchRenderConfig, ObjectRotation,
-    PersistentRenderer, RenderConfig, RenderOutput, RenderSession, ViewpointConfig,
+    PersistentRenderer, RenderConfig, RenderOutput, RenderSession, TargetingPolicy, Vec3,
+    ViewpointConfig,
 };
 use std::fs;
 use std::path::PathBuf;
@@ -192,6 +193,8 @@ fn test_batch_render_matches_sequential_episode_outputs() {
             viewpoint: *viewpoint,
             object_rotation: rotation.clone(),
             render_config: config.clone(),
+            target_point: Vec3::ZERO,
+            targeting_policy: TargetingPolicy::Origin,
         })
         .collect();
 
@@ -319,6 +322,8 @@ fn test_session_vs_fresh_n_batch_smoke() {
                     viewpoint: *vp,
                     object_rotation: rotation.clone(),
                     render_config: config.clone(),
+                    target_point: Vec3::ZERO,
+                    targeting_policy: TargetingPolicy::Origin,
                 })
                 .collect()
         })
@@ -511,6 +516,8 @@ fn test_render_session_matches_sequential_across_objects() {
                     viewpoint: *vp,
                     object_rotation: rotation.clone(),
                     render_config: config.clone(),
+                    target_point: Vec3::ZERO,
+                    targeting_policy: TargetingPolicy::Origin,
                 })
                 .collect();
             session.render(&requests).expect("session render failed")
@@ -928,6 +935,8 @@ fn test_persistent_renderer_per_step_throughput_smoke() {
             viewpoint: *vp,
             object_rotation: rotation.clone(),
             render_config: config.clone(),
+            target_point: Vec3::ZERO,
+            targeting_policy: TargetingPolicy::Origin,
         };
         let _ = session.render(&[req]).expect("session render failed");
     }


### PR DESCRIPTION
## Summary

- add target-aware TBP/YCB viewpoint generation with mesh-center targeting and serializable targeting policy metadata
- add render health and surface-point helpers on `RenderOutput`, plus batch-level health summaries
- add fail-fast `prerender --validate-center-hit` and mesh-center manifest/index metadata for downstream NeoCortx cache/debug workflows

## NeoCortx impact

This is the renderer-side implementation for #81. NeoCortx can consume this to remove local OBJ-center parsing, centered-viewpoint generation, center-depth/surface-point helpers, and render-health rescans. The handoff notes are linked from #81 and targeted into `killerapp/neocortx#197`, `#343`, and `#374`.

## Validation

- `cargo test`
- `cargo check --all-targets`
- `cargo check --bin prerender`
- `git diff --check`
- `cargo run --bin prerender -- --validate-center-hit --data-dir C:\tmp\ycb --objects "033_spatula,057_racquetball,063-b_marbles,065-e_cups,073-f_lego_duplo" --target mesh-center --rotation-schedule tbp-parity --validation-report target\center_hit_validation_timeout_objects.json`
- `cargo run --bin prerender -- --data-dir C:\tmp\ycb --objects 057_racquetball --target mesh-center --rotation-schedule tbp-parity --output-dir target\prerender_mesh_center_smoke`

Refs #81.
